### PR TITLE
Add rule-based optimization flow for quotations

### DIFF
--- a/guillotine_optimization.php
+++ b/guillotine_optimization.php
@@ -1,0 +1,250 @@
+<?php
+require __DIR__ . '/header.php';
+
+function e(?string $v): string {
+    return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function fmtPrice(float $v): string {
+    return number_format($v, 2, ',', '.') . ' ₺';
+}
+
+function fetchProduct(PDO $pdo, string $name): array {
+    $stmt = $pdo->prepare('SELECT unit_price, weight_per_meter FROM products WHERE name = :name');
+    $stmt->execute(['name' => $name]);
+    $row = $stmt->fetch();
+    if (!$row) {
+        return ['unit_price' => 0, 'weight_per_meter' => 0];
+    }
+    return ['unit_price' => (float)$row['unit_price'], 'weight_per_meter' => (float)($row['weight_per_meter'] ?? 0)];
+}
+
+$results = [];
+$grandTotal = 0.0;
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $width = isset($_POST['width']) ? (float)$_POST['width'] : 0;
+    $height = isset($_POST['height']) ? (float)$_POST['height'] : 0;
+    $quantity = isset($_POST['quantity']) ? (int)$_POST['quantity'] : 0;
+    $kenetliQty = isset($_POST['kenetli_qty']) ? (int)$_POST['kenetli_qty'] : 0;
+    $kupesteBazaQty = isset($_POST['kupeste_baza_qty']) ? (int)$_POST['kupeste_baza_qty'] : 0;
+
+    if ($width <= 0) { $errors[] = 'Sistem genişliği pozitif olmalıdır.'; }
+    if ($height <= 0) { $errors[] = 'Sistem yüksekliği pozitif olmalıdır.'; }
+    if ($quantity <= 0) { $errors[] = 'Sistem adedi pozitif olmalıdır.'; }
+    if ($kenetliQty <= 0) { $errors[] = 'Kenetli baza adedi pozitif olmalıdır.'; }
+    if ($kupesteBazaQty <= 0) { $errors[] = 'Küpeşte bazası adedi pozitif olmalıdır.'; }
+
+    if (!$errors) {
+        // Pre-computed quantities
+        $motorKutusuMeasurement = $width - 14;
+        $motorKutusuQty = $quantity;
+        $motorKutusuGasket = $motorKutusuMeasurement * $motorKutusuQty;
+
+        $altKasaMeasurement = $width;
+        $altKasaQty = $quantity;
+        $altKasaGasket = $altKasaMeasurement * $altKasaQty;
+
+        $tutamakMeasurement = $width - 185;
+        $tutamakQty = 6 * $quantity - ($kenetliQty + $kupesteBazaQty);
+        $tutamakGasket = $tutamakMeasurement * $tutamakQty;
+
+        $kenetliMeasurement = $width - 185;
+        $kenetliBazaQtyCalc = 3 * $quantity;
+        $kenetliGasket = $kenetliMeasurement * $kenetliBazaQtyCalc;
+
+        $kupesteBazasiMeasurement = $width - 185;
+        $kupesteBazasiQtyCalc = 2 * $quantity;
+
+        $kupesteMeasurement = $width - 185;
+        $kupesteQty = $quantity;
+
+        $yatayCitaMeasurement = $kenetliMeasurement - 52;
+        $yatayCitaQty = $tutamakQty + $kenetliBazaQtyCalc + $kupesteBazasiQtyCalc;
+
+        $verticalBaseMeasurement = ($height - 290) / 3;
+        $dikeyCitaMeasurement = $verticalBaseMeasurement - 5;
+        $dikeyCitaQty = $yatayCitaQty;
+
+        $dikmeMeasurement = $height - 166;
+        $dikmeQty = 2 * $quantity;
+        $dikmeGasket = $dikmeMeasurement * $dikmeQty;
+
+        $ortaDikmeMeasurement = $height - 166;
+        $ortaDikmeQty = 2 * $quantity;
+        $ortaDikmeGasket = $ortaDikmeMeasurement * $ortaDikmeQty * 2;
+
+        $wingMeasurement = ($height - 290) / 3;
+        $sonKapatmaMeasurement = $height - $wingMeasurement - 221;
+        $sonKapatmaQty = 2 * $quantity;
+        $sonKapatmaGasket = $sonKapatmaMeasurement * $sonKapatmaQty;
+
+        $kanatMeasurement = $wingMeasurement;
+        $kanatQty = 2 * $quantity;
+        $kanatLongGasket = $kanatMeasurement * $kanatQty;
+        $wingGasket = $kanatMeasurement * $kanatQty * 2;
+
+        $dikeyBazaMeasurement = $wingMeasurement;
+        $dikeyBazaQty = $quantity * 4;
+
+        $zincirMeasurement = $height - $wingMeasurement - 221 + 600;
+        $zincirQty = 2 * $quantity;
+
+        $flatbeltMeasurement = $zincirMeasurement;
+        $flatbeltQty = 2 * $quantity;
+
+        $motorBorusuMeasurement = $width - 59;
+        $motorBorusuQty = $quantity;
+
+        $motorKutuContasiMeasurement = $motorKutusuGasket + $altKasaGasket; // mm
+        $kanatContasiMeasurement = $wingGasket; // mm
+
+        $partsDef = [
+            ['Motor Kutusu', $motorKutusuMeasurement, $motorKutusuQty, $motorKutusuGasket],
+            ['Motor Kapak', $width - 15, $quantity, null],
+            ['Alt Kasa', $altKasaMeasurement, $altKasaQty, $altKasaGasket],
+            ['Tutamak', $tutamakMeasurement, $tutamakQty, $tutamakGasket],
+            ['Kenetli Baza', $kenetliMeasurement, $kenetliBazaQtyCalc, $kenetliGasket],
+            ['Küpeşte Bazası', $kupesteBazasiMeasurement, $kupesteBazasiQtyCalc, null],
+            ['Küpeşte', $kupesteMeasurement, $kupesteQty, null],
+            ['Yatay Tek Cam Çıtası', $yatayCitaMeasurement, $yatayCitaQty, null],
+            ['Dikey Tek Cam Çıtası', $dikeyCitaMeasurement, $dikeyCitaQty, null],
+            ['Dikme', $dikmeMeasurement, $dikmeQty, $dikmeGasket],
+            ['Orta Dikme', $ortaDikmeMeasurement, $ortaDikmeQty, $ortaDikmeGasket],
+            ['Son Kapatma', $sonKapatmaMeasurement, $sonKapatmaQty, $sonKapatmaGasket],
+            ['Kanat', $kanatMeasurement, $kanatQty, $kanatLongGasket, $wingGasket],
+            ['Dikey Baza', $dikeyBazaMeasurement, $dikeyBazaQty, null],
+            ['Zincir', $zincirMeasurement, $zincirQty, null],
+            ['Flatbelt Kayış', $flatbeltMeasurement, $flatbeltQty, null],
+            ['Motor Borusu', $motorBorusuMeasurement, $motorBorusuQty, null],
+            ['Motor Kutu Contası', $motorKutuContasiMeasurement, 1, null],
+            ['Kanat Contası', $kanatContasiMeasurement, 1, null],
+        ];
+
+        foreach ($partsDef as $def) {
+            [$name, $measurement, $qtyPart, $gasketExtra, $wingGasketExtra] = array_pad($def, 5, null);
+            $product = fetchProduct($pdo, $name);
+            $totalKg = ($product['weight_per_meter'] * $measurement * $qtyPart) / 1000;
+            $unitPrice = $product['unit_price'];
+            $totalPrice = $totalKg * $unitPrice;
+            $extraInfo = '';
+            if ($name === 'Motor Kutusu') {
+                $extraInfo = 'Motor Kutu Contası: ' . $motorKutusuGasket . ' mm';
+            } elseif ($name === 'Alt Kasa') {
+                $extraInfo = 'Motor Kutu Contası: ' . $altKasaGasket . ' mm';
+            } elseif ($name === 'Tutamak') {
+                $extraInfo = 'Kısa Fitil: ' . $tutamakGasket . ' mm';
+            } elseif ($name === 'Kenetli Baza') {
+                $extraInfo = 'Kısa Fitil: ' . $kenetliGasket . ' mm';
+            } elseif ($name === 'Dikme') {
+                $extraInfo = 'Uzun Fitil: ' . $dikmeGasket . ' mm';
+            } elseif ($name === 'Orta Dikme') {
+                $extraInfo = 'Uzun Fitil: ' . $ortaDikmeGasket . ' mm';
+            } elseif ($name === 'Son Kapatma') {
+                $extraInfo = 'Uzun Fitil: ' . $sonKapatmaGasket . ' mm';
+            } elseif ($name === 'Kanat') {
+                $extraInfo = 'Uzun Fitil: ' . $kanatLongGasket . ' mm, Kanat Fitili: ' . $wingGasket . ' mm';
+            } elseif ($name === 'Motor Kutu Contası') {
+                $extraInfo = 'Uzunluk: ' . number_format($motorKutuContasiMeasurement / 1000, 2, ',', '.') . ' m';
+            } elseif ($name === 'Kanat Contası') {
+                $extraInfo = 'Uzunluk: ' . number_format($kanatContasiMeasurement / 1000, 2, ',', '.') . ' m';
+            }
+
+            $results[] = [
+                'name' => $name,
+                'measurement' => $measurement,
+                'quantity' => $qtyPart,
+                'total_kg' => $totalKg,
+                'unit_price' => $unitPrice,
+                'total_price' => $totalPrice,
+                'extra' => $extraInfo,
+            ];
+            $grandTotal += $totalPrice;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <title>Guillotine Optimization</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-4">
+    <h1>Guillotine Optimization</h1>
+    <?php if ($errors): ?>
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                <?php foreach ($errors as $e): ?>
+                    <li><?= e($e) ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+    <form method="post" class="row g-3 mb-4">
+        <div class="col-md-2">
+            <label class="form-label">System Width (mm)</label>
+            <input type="number" name="width" step="0.01" class="form-control" value="<?= e($_POST['width'] ?? '') ?>" required>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">System Height (mm)</label>
+            <input type="number" name="height" step="0.01" class="form-control" value="<?= e($_POST['height'] ?? '') ?>" required>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">System Quantity</label>
+            <input type="number" name="quantity" class="form-control" value="<?= e($_POST['quantity'] ?? '') ?>" required>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">Kenetli Baza Quantity</label>
+            <input type="number" name="kenetli_qty" class="form-control" value="<?= e($_POST['kenetli_qty'] ?? '') ?>" required>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">Küpeşte Bazası Quantity</label>
+            <input type="number" name="kupeste_baza_qty" class="form-control" value="<?= e($_POST['kupeste_baza_qty'] ?? '') ?>" required>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Hesapla</button>
+        </div>
+    </form>
+
+    <?php if ($results): ?>
+    <div class="table-responsive">
+        <table class="table table-bordered table-striped">
+            <thead>
+                <tr>
+                    <th>Part Name</th>
+                    <th>Measurement (mm)</th>
+                    <th>Quantity</th>
+                    <th>Total Weight (kg)</th>
+                    <th>Unit Price</th>
+                    <th>Total Price</th>
+                    <th>Extra Info</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($results as $r): ?>
+                    <tr>
+                        <td><?= e($r['name']) ?></td>
+                        <td><?= e(number_format($r['measurement'], 2, ',', '.')) ?></td>
+                        <td><?= e($r['quantity']) ?></td>
+                        <td><?= e(number_format($r['total_kg'], 3, ',', '.')) ?></td>
+                        <td><?= e(fmtPrice($r['unit_price'])) ?></td>
+                        <td><?= e(fmtPrice($r['total_price'])) ?></td>
+                        <td><?= e($r['extra']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th colspan="5" class="text-end">Grand Total</th>
+                    <th><?= e(fmtPrice($grandTotal)) ?></th>
+                    <th></th>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+    <?php endif; ?>
+</body>
+</html>

--- a/guillotine_optimization.php
+++ b/guillotine_optimization.php
@@ -10,13 +10,19 @@ function fmtPrice(float $v): string {
 }
 
 function fetchProduct(PDO $pdo, string $name): array {
-    $stmt = $pdo->prepare('SELECT unit_price, weight_per_meter FROM products WHERE name = :name');
+    $stmt = $pdo->prepare('SELECT p.unit_price, p.weight_per_meter, p.width, p.height, c.unit_type FROM products p LEFT JOIN categories c ON p.category = c.id WHERE p.name = :name');
     $stmt->execute(['name' => $name]);
-    $row = $stmt->fetch();
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$row) {
-        return ['unit_price' => 0, 'weight_per_meter' => 0];
+        return ['unit_price' => 0, 'weight_per_meter' => 0, 'width' => 0, 'height' => 0, 'unit_type' => ''];
     }
-    return ['unit_price' => (float)$row['unit_price'], 'weight_per_meter' => (float)($row['weight_per_meter'] ?? 0)];
+    return [
+        'unit_price' => (float)$row['unit_price'],
+        'weight_per_meter' => (float)($row['weight_per_meter'] ?? 0),
+        'width' => (float)($row['width'] ?? 0),
+        'height' => (float)($row['height'] ?? 0),
+        'unit_type' => $row['unit_type'] ?? '',
+    ];
 }
 
 $results = [];
@@ -125,9 +131,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         foreach ($partsDef as $def) {
             [$name, $measurement, $qtyPart, $gasketExtra, $wingGasketExtra] = array_pad($def, 5, null);
             $product = fetchProduct($pdo, $name);
-            $totalKg = ($product['weight_per_meter'] * $measurement * $qtyPart) / 1000;
             $unitPrice = $product['unit_price'];
-            $totalPrice = $totalKg * $unitPrice;
+            $unitType = $product['unit_type'];
+            $length = ($measurement * $qtyPart) / 1000; // m
+            $totalKg = null;
+            switch ($unitType) {
+                case 'kg/m':
+                    $totalKg = $product['weight_per_meter'] * $length;
+                    $totalPrice = $totalKg * $unitPrice;
+                    break;
+                case 'm':
+                    $totalPrice = $length * $unitPrice;
+                    break;
+                case 'm²':
+                    $area = ($product['width'] * $product['height'] / 1000000) * $qtyPart;
+                    $totalPrice = $area * $unitPrice;
+                    break;
+                default: // adet
+                    $totalPrice = $qtyPart * $unitPrice;
+            }
             $extraInfo = '';
             if ($name === 'Motor Kutusu') {
                 $extraInfo = 'Motor Kutu Contası: ' . $motorKutusuGasket . ' mm';
@@ -229,7 +251,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         <td><?= e($r['name']) ?></td>
                         <td><?= e(number_format($r['measurement'], 2, ',', '.')) ?></td>
                         <td><?= e($r['quantity']) ?></td>
-                        <td><?= e(number_format($r['total_kg'], 3, ',', '.')) ?></td>
+                        <td><?= $r['total_kg'] !== null ? e(number_format($r['total_kg'], 3, ',', '.')) : '-' ?></td>
                         <td><?= e(fmtPrice($r['unit_price'])) ?></td>
                         <td><?= e(fmtPrice($r['total_price'])) ?></td>
                         <td><?= e($r['extra']) ?></td>

--- a/products.php
+++ b/products.php
@@ -18,9 +18,11 @@ function formatPrice(float $price): string
 $errors = [];
 $error = null;
 $success = null;
-$unitOptions = ['adet', 'kilogram', 'litre', 'metre', 'metrekare', 'paket'];
 $vatAllowed = [1, 8, 18, 20];
 $action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+$catStmt = $pdo->query('SELECT id, name, unit_type FROM categories ORDER BY name');
+$categories = $catStmt->fetchAll(PDO::FETCH_ASSOC);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
   $action = $_POST['action'] ?? '';
@@ -42,15 +44,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
     $id = (int)($_POST['id'] ?? 0);
     $product_code = trim($_POST['product_code'] ?? '');
     $name = trim($_POST['name'] ?? '');
-    $category = trim($_POST['category'] ?? '');
-    $unit = trim($_POST['unit'] ?? '');
-    if ($unit !== '' && !in_array($unit, $unitOptions, true)) {
-      $errors[] = 'Geçersiz birim.';
+    $category_id = (int)($_POST['category_id'] ?? 0);
+    $unit_type = '';
+    if ($category_id <= 0) {
+      $errors[] = 'Kategori seçilmelidir.';
     }
+    if ($category_id > 0) {
+      $uStmt = $pdo->prepare('SELECT unit_type FROM categories WHERE id = :id');
+      $uStmt->execute([':id' => $category_id]);
+      $unit_type = $uStmt->fetchColumn() ?: '';
+    }
+    $unit = $unit_type;
     $color = trim($_POST['color'] ?? '');
     $description = trim($_POST['description'] ?? '');
     $unit_price = trim($_POST['unit_price'] ?? '');
     $vat_rate = trim($_POST['vat_rate'] ?? '');
+    $weight_per_meter = $unit_type === 'kg/m' ? (float)($_POST['weight_per_meter'] ?? 0) : null;
+    $widthVal = $unit_type === 'm²' ? (float)($_POST['width'] ?? 0) : null;
+    $heightVal = $unit_type === 'm²' ? (float)($_POST['height'] ?? 0) : null;
+    if ($unit_type === 'kg/m' && $weight_per_meter <= 0) {
+      $errors[] = 'Ağırlık (kg/m) > 0 olmalıdır.';
+    }
+    if ($unit_type === 'm²' && ($widthVal <= 0 || $heightVal <= 0)) {
+      $errors[] = 'Genişlik ve yükseklik > 0 olmalıdır.';
+    }
     if ($vat_rate === '') {
       $vat_rate = null;
     } elseif (!in_array((int)$vat_rate, $vatAllowed, true)) {
@@ -96,16 +113,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
 
     if (!$errors) {
       try {
-        $stmt = $pdo->prepare('UPDATE products SET product_code=:product_code, name=:name, category=:category, unit=:unit, color=:color, description=:description, unit_price=:unit_price, vat_rate=:vat_rate, image_data=:image_data, image_mime=:image_mime WHERE id=:id');
+        $stmt = $pdo->prepare('UPDATE products SET product_code=:product_code, name=:name, category=:category, unit=:unit, color=:color, description=:description, unit_price=:unit_price, vat_rate=:vat_rate, weight_per_meter=:wpm, width=:width, height=:height, image_data=:image_data, image_mime=:image_mime WHERE id=:id');
         $stmt->execute([
           ':product_code' => $product_code ?: null,
           ':name' => $name,
-          ':category' => $category ?: null,
+          ':category' => $category_id ?: null,
           ':unit' => $unit ?: null,
           ':color' => $color ?: null,
           ':description' => $description ?: null,
           ':unit_price' => $unit_price,
           ':vat_rate' => $vat_rate !== '' ? $vat_rate : null,
+          ':wpm' => $weight_per_meter,
+          ':width' => $widthVal,
+          ':height' => $heightVal,
           ':image_data' => $imageData,
           ':image_mime' => $imageMime,
           ':id' => $id,
@@ -121,15 +141,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
   } elseif ($action === 'create') {
     $product_code = trim($_POST['product_code'] ?? '');
     $name = trim($_POST['name'] ?? '');
-    $category = trim($_POST['category'] ?? '');
-    $unit = trim($_POST['unit'] ?? '');
-    if ($unit !== '' && !in_array($unit, $unitOptions, true)) {
-      $errors[] = 'Geçersiz birim.';
+    $category_id = (int)($_POST['category_id'] ?? 0);
+    $unit_type = '';
+    if ($category_id <= 0) {
+      $errors[] = 'Kategori seçilmelidir.';
     }
+    if ($category_id > 0) {
+      $uStmt = $pdo->prepare('SELECT unit_type FROM categories WHERE id = :id');
+      $uStmt->execute([':id' => $category_id]);
+      $unit_type = $uStmt->fetchColumn() ?: '';
+    }
+    $unit = $unit_type;
     $color = trim($_POST['color'] ?? '');
     $description = trim($_POST['description'] ?? '');
     $unit_price = trim($_POST['unit_price'] ?? '');
     $vat_rate = trim($_POST['vat_rate'] ?? '');
+    $weight_per_meter = $unit_type === 'kg/m' ? (float)($_POST['weight_per_meter'] ?? 0) : null;
+    $widthVal = $unit_type === 'm²' ? (float)($_POST['width'] ?? 0) : null;
+    $heightVal = $unit_type === 'm²' ? (float)($_POST['height'] ?? 0) : null;
+    if ($unit_type === 'kg/m' && $weight_per_meter <= 0) {
+      $errors[] = 'Ağırlık (kg/m) > 0 olmalıdır.';
+    }
+    if ($unit_type === 'm²' && ($widthVal <= 0 || $heightVal <= 0)) {
+      $errors[] = 'Genişlik ve yükseklik > 0 olmalıdır.';
+    }
     if ($vat_rate === '') {
       $vat_rate = null;
     } elseif (!in_array((int)$vat_rate, $vatAllowed, true)) {
@@ -174,16 +209,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
 
     if (!$errors) {
       try {
-        $stmt = $pdo->prepare('INSERT INTO products (product_code, name, category, unit, color, description, unit_price, vat_rate, image_data, image_mime) VALUES (:product_code, :name, :category, :unit, :color, :description, :unit_price, :vat_rate, :image_data, :image_mime)');
+        $stmt = $pdo->prepare('INSERT INTO products (product_code, name, category, unit, color, description, unit_price, vat_rate, weight_per_meter, width, height, image_data, image_mime) VALUES (:product_code, :name, :category, :unit, :color, :description, :unit_price, :vat_rate, :wpm, :width, :height, :image_data, :image_mime)');
         $stmt->execute([
           ':product_code' => $product_code,
           ':name' => $name,
-          ':category' => $category ?: null,
+          ':category' => $category_id ?: null,
           ':unit' => $unit ?: null,
           ':color' => $color ?: null,
           ':description' => $description ?: null,
           ':unit_price' => $unit_price,
           ':vat_rate' => $vat_rate !== '' ? $vat_rate : null,
+          ':wpm' => $weight_per_meter,
+          ':width' => $widthVal,
+          ':height' => $heightVal,
           ':image_data' => $imageData,
           ':image_mime' => $imageMime,
         ]);
@@ -195,91 +233,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
     } else {
       $error = implode(' ', $errors);
     }
-  }
-} elseif ($action === 'edit') {
-  $id = (int)($_POST['id'] ?? 0);
-  $product_code = trim($_POST['product_code'] ?? '');
-  $name = trim($_POST['name'] ?? '');
-  $category = trim($_POST['category'] ?? '');
-  $unit = trim($_POST['unit'] ?? '');
-  $color = trim($_POST['color'] ?? '');
-  $description = trim($_POST['description'] ?? '');
-  $unit_price = trim($_POST['unit_price'] ?? '');
-  $vat_rate = trim($_POST['vat_rate'] ?? '');
-  if ($vat_rate === '') {
-    $vat_rate = null;
-  } elseif (!in_array((int)$vat_rate, $vatAllowed, true)) {
-    $errors[] = 'KDV oranı sadece %1, %8, %18 veya %20 olabilir.';
-  } else {
-    $vat_rate = (int)$vat_rate;
-  }
-
-  if ($name === '') {
-    $errors[] = 'Ürün adı zorunludur.';
-  }
-  if ($unit_price === '' || !is_numeric($unit_price)) {
-    $errors[] = 'Birim fiyatı geçerli bir sayı olmalıdır.';
-  }
-  if ($vat_rate !== '' && !is_numeric($vat_rate)) {
-    $errors[] = 'KDV oranı geçerli bir sayı olmalıdır.';
-  }
-
-  $stmt = $pdo->prepare('SELECT image_data, image_mime FROM products WHERE id = :id');
-  $stmt->execute(['id' => $id]);
-  $current = $stmt->fetch(PDO::FETCH_ASSOC);
-  if (!$current) {
-    $errors[] = 'Ürün bulunamadı.';
-  }
-
-  $imageData = $current['image_data'] ?? null;
-  $imageMime = $current['image_mime'] ?? null;
-
-  if (!empty($_FILES['image']['tmp_name'])) {
-    if ($_FILES['image']['size'] > 2 * 1024 * 1024) {
-      $errors[] = 'Resim 2MB\'yi aşamaz.';
-    } else {
-      $finfo = new finfo(FILEINFO_MIME_TYPE);
-      $mime = $finfo->file($_FILES['image']['tmp_name']);
-      if (!in_array($mime, ['image/jpeg', 'image/png'], true)) {
-        $errors[] = 'Yalnızca JPEG veya PNG dosyaları kabul edilir.';
-      } else {
-        $imageData = file_get_contents($_FILES['image']['tmp_name']);
-        $imageMime = $mime;
-      }
     }
   }
+  $success = filter_input(INPUT_GET, 'success', FILTER_SANITIZE_SPECIAL_CHARS);
+  $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
 
-  if (!$errors) {
-    try {
-      $stmt = $pdo->prepare('UPDATE products SET product_code=:product_code, name=:name, category=:category, unit=:unit, color=:color, description=:description, unit_price=:unit_price, vat_rate=:vat_rate, image_data=:image_data, image_mime=:image_mime WHERE id=:id');
-      $stmt->execute([
-        ':product_code' => $product_code ?: null,
-        ':name' => $name,
-        ':category' => $category ?: null,
-        ':unit' => $unit ?: null,
-        ':color' => $color ?: null,
-        ':description' => $description ?: null,
-        ':unit_price' => $unit_price,
-        ':vat_rate' => $vat_rate !== '' ? $vat_rate : null,
-        ':image_data' => $imageData,
-        ':image_mime' => $imageMime,
-        ':id' => $id,
-      ]);
-      header('Location: products?success=' . urlencode('Ürün güncellendi.'));
-      exit;
-    } catch (Exception $e) {
-      $error = 'Ürün güncellenemedi.';
-    }
-  } else {
-    $error = implode(' ', $errors);
-  }
-}
-
-$success = filter_input(INPUT_GET, 'success', FILTER_SANITIZE_SPECIAL_CHARS);
-$error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
-
-$stmt = $pdo->query('SELECT id, product_code, name, category, unit, color, image_data, image_mime, description, unit_price, vat_rate FROM products ORDER BY id DESC');
-$products = $stmt->fetchAll();
+$stmt = $pdo->query('SELECT p.id, p.product_code, p.name, p.category, p.unit, p.color, p.image_data, p.image_mime, p.description, p.unit_price, p.vat_rate, p.weight_per_meter, p.width, p.height, c.name AS category_name, c.unit_type FROM products p LEFT JOIN categories c ON p.category = c.id ORDER BY p.id DESC');
+$products = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <div class="container py-4">
   <div class="d-flex justify-content-between align-items-center mb-3">
@@ -320,7 +280,7 @@ $products = $stmt->fetchAll();
             <div class="card-body">
               <h5 class="card-title"><?= e($p['name']) ?></h5>
               <?php if ($p['category']): ?>
-                <p class="card-text mb-1"><?= e($p['category']) ?></p>
+                <p class="card-text mb-1"><?= e($p['category_name']) ?></p>
               <?php endif; ?>
               <?php if ($p['color'] || $p['unit']): ?>
                 <p class="card-text mb-1"><?= e($p['color']) ?> <?= e($p['unit']) ?></p>
@@ -360,17 +320,29 @@ $products = $stmt->fetchAll();
                             <input type="text" name="name" class="form-control" required value="<?= e($p['name']) ?>">
                           </div>
                           <div class="col-md-6">
-                            <label class="form-label">Kategori</label>
-                            <input type="text" name="category" class="form-control" value="<?= e($p['category']) ?>">
-                          </div>
-                          <div class="col-md-6">
-                            <label class="form-label">Birim</label>
-                            <select name="unit" class="form-select">
-                              <option value=""></option>
-                              <?php foreach ($unitOptions as $u): ?>
-                                <option value="<?= e($u) ?>" <?= ($p['unit'] === $u) ? 'selected' : '' ?>><?= e($u) ?></option>
+                            <label class="form-label">Kategori *</label>
+                            <select name="category_id" class="form-select category-select" required>
+                              <option value="">Seçiniz</option>
+                              <?php foreach ($categories as $cat): ?>
+                                <option value="<?= $cat['id'] ?>" data-unit-type="<?= e($cat['unit_type']) ?>" <?= ((int)$p['category'] === (int)$cat['id']) ? 'selected' : '' ?>><?= e($cat['name']) ?></option>
                               <?php endforeach; ?>
                             </select>
+                          </div>
+                          <div class="col-md-6">
+                            <label class="form-label">Birim Türü</label>
+                            <input type="text" class="form-control unit-display" value="<?= e($p['unit']) ?>" readonly>
+                          </div>
+                          <div class="col-md-6 kgm-field">
+                            <label class="form-label">Ağırlık (kg/m)</label>
+                            <input type="number" step="0.001" name="weight_per_meter" class="form-control" value="<?= e($p['weight_per_meter']) ?>">
+                          </div>
+                          <div class="col-md-6 m2-field">
+                            <label class="form-label">Genişlik (mm)</label>
+                            <input type="number" step="0.01" name="width" class="form-control" value="<?= e($p['width']) ?>">
+                          </div>
+                          <div class="col-md-6 m2-field">
+                            <label class="form-label">Yükseklik (mm)</label>
+                            <input type="number" step="0.01" name="height" class="form-control" value="<?= e($p['height']) ?>">
                           </div>
                           <div class="col-md-6">
                             <label class="form-label">Renk</label>
@@ -441,17 +413,29 @@ $products = $stmt->fetchAll();
                   <input type="text" name="name" class="form-control" required>
                 </div>
                 <div class="col-md-6">
-                  <label class="form-label">Kategori</label>
-                  <input type="text" name="category" class="form-control">
-                </div>
-                <div class="col-md-6">
-                  <label class="form-label">Birim</label>
-                  <select name="unit" class="form-select">
-                    <option value=""></option>
-                    <?php foreach ($unitOptions as $u): ?>
-                      <option value="<?= e($u) ?>"><?= e($u) ?></option>
+                  <label class="form-label">Kategori *</label>
+                  <select name="category_id" class="form-select category-select" required>
+                    <option value="">Seçiniz</option>
+                    <?php foreach ($categories as $cat): ?>
+                      <option value="<?= $cat['id'] ?>" data-unit-type="<?= e($cat['unit_type']) ?>"><?= e($cat['name']) ?></option>
                     <?php endforeach; ?>
                   </select>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Birim Türü</label>
+                  <input type="text" class="form-control unit-display" readonly>
+                </div>
+                <div class="col-md-6 kgm-field">
+                  <label class="form-label">Ağırlık (kg/m)</label>
+                  <input type="number" step="0.001" name="weight_per_meter" class="form-control">
+                </div>
+                <div class="col-md-6 m2-field">
+                  <label class="form-label">Genişlik (mm)</label>
+                  <input type="number" step="0.01" name="width" class="form-control">
+                </div>
+                <div class="col-md-6 m2-field">
+                  <label class="form-label">Yükseklik (mm)</label>
+                  <input type="number" step="0.01" name="height" class="form-control">
                 </div>
                 <div class="col-md-6">
                   <label class="form-label">Renk</label>
@@ -491,6 +475,20 @@ $products = $stmt->fetchAll();
     </div>
   <?php endif; ?>
 </div>
+<script>
+document.querySelectorAll('.category-select').forEach(function(sel){
+  function update(){
+    var unit = sel.options[sel.selectedIndex]?.dataset.unitType || '';
+    var form = sel.closest('form');
+    var display = form.querySelector('.unit-display');
+    if (display) display.value = unit;
+    form.querySelectorAll('.kgm-field').forEach(function(el){ el.classList.toggle('d-none', unit !== 'kg/m'); });
+    form.querySelectorAll('.m2-field').forEach(function(el){ el.classList.toggle('d-none', unit !== 'm²'); });
+  }
+  sel.addEventListener('change', update);
+  update();
+});
+</script>
 </body>
 
 </html>

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -53,6 +53,129 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'delet
     }
 }
 
+// Handle optimize action
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    ($_POST['action'] ?? '') === 'optimize' &&
+    $role === 'admin'
+) {
+    $token  = $_POST['csrf_token'] ?? '';
+    $postId = (int)($_POST['id'] ?? 0);
+    if (!hash_equals($csrfToken, $token) || $postId !== $id) {
+        $_SESSION['flash_error'] = 'Geçersiz CSRF tokenı.';
+    } else {
+        $rules = require __DIR__ . '/rules.php';
+        try {
+            $pdo->beginTransaction();
+
+            $pStmt = $pdo->prepare('SELECT unit_price, vat_rate FROM products WHERE product_code = :code');
+
+            // --- Guillotine systems ---
+            $gFetch = $pdo->prepare('SELECT * FROM guillotinesystems WHERE general_offer_id = :id');
+            $gFetch->execute([':id' => $id]);
+            $gUpd = $pdo->prepare('UPDATE guillotinesystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
+            $gTotal = 0.0;
+            foreach ($gFetch->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $width    = (float)$row['width'];
+                $height   = (float)$row['height'];
+                $qty      = (int)$row['quantity'];
+                $remote   = $row['remote_quantity'] !== null ? (int)$row['remote_quantity'] : 0;
+                if ($width <= 0 || $height <= 0 || $qty <= 0 || $remote < 0) {
+                    throw new RuntimeException('Geçersiz giyotin verisi.');
+                }
+
+                $base = 0.0;
+                foreach ($rules['guillotine'] ?? [] as $rule) {
+                    if (!is_callable($rule['match']) || !$rule['match']($row)) {
+                        continue;
+                    }
+                    foreach ($rule['products'] as $prod) {
+                        $calcQty = (float)$prod['qty']($row);
+                        if ($calcQty <= 0) {
+                            continue;
+                        }
+                        $pStmt->execute([':code' => $prod['code']]);
+                        if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
+                            $unit = (float)$p['unit_price'];
+                            $vat  = (float)$p['vat_rate'];
+                            $base += $calcQty * $unit * (1 + $vat / 100);
+                        }
+                    }
+                }
+                $rate = (float)($row['profit_rate'] ?? $row['profit_margin'] ?? 0);
+                $profitAmount = $base * ($rate / 100);
+                $totalAmount  = $base + $profitAmount;
+                $gUpd->execute([
+                    ':pamount' => $profitAmount,
+                    ':tamount' => $totalAmount,
+                    ':id'      => $row['id'],
+                ]);
+                $gTotal += $totalAmount;
+            }
+
+            // --- Sliding systems ---
+            $sFetch = $pdo->prepare('SELECT * FROM slidingsystems WHERE general_offer_id = :id');
+            $sFetch->execute([':id' => $id]);
+            $sUpd = $pdo->prepare('UPDATE slidingsystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
+            $sTotal = 0.0;
+            foreach ($sFetch->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $width  = (float)$row['width'];
+                $height = (float)$row['height'];
+                $qty    = (int)$row['quantity'];
+                if ($width <= 0 || $height <= 0 || $qty <= 0) {
+                    throw new RuntimeException('Geçersiz sürme verisi.');
+                }
+
+                $base = 0.0;
+                foreach ($rules['sliding'] ?? [] as $rule) {
+                    if (!is_callable($rule['match']) || !$rule['match']($row)) {
+                        continue;
+                    }
+                    foreach ($rule['products'] as $prod) {
+                        $calcQty = (float)$prod['qty']($row);
+                        if ($calcQty <= 0) {
+                            continue;
+                        }
+                        $pStmt->execute([':code' => $prod['code']]);
+                        if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
+                            $unit = (float)$p['unit_price'];
+                            $vat  = (float)$p['vat_rate'];
+                            $base += $calcQty * $unit * (1 + $vat / 100);
+                        }
+                    }
+                }
+
+                if ($base > 0) {
+                    $rate = (float)($row['profit_rate'] ?? $row['profit_margin'] ?? 0);
+                    $profitAmount = $base * ($rate / 100);
+                    $totalAmount  = $base + $profitAmount;
+                    $sUpd->execute([
+                        ':pamount' => $profitAmount,
+                        ':tamount' => $totalAmount,
+                        ':id'      => $row['id'],
+                    ]);
+                    $sTotal += $totalAmount;
+                } else {
+                    $sTotal += (float)$row['total_amount'];
+                }
+            }
+
+            // Update general offer total
+            $overall = $gTotal + $sTotal;
+            $gUpdTotal = $pdo->prepare('UPDATE generaloffers SET total_amount = :t WHERE id = :id');
+            $gUpdTotal->execute([':t' => $overall, ':id' => $id]);
+
+            $pdo->commit();
+            $_SESSION['flash_success'] = 'Optimize işlemi tamamlandı.';
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            $_SESSION['flash_error'] = 'Optimize işleminde hata oluştu.';
+        }
+    }
+    header('Location: quotation_view.php?id=' . $id);
+    exit;
+}
+
 try {
     $stmt = $pdo->prepare('
         SELECT g.*, c.first_name, c.last_name, c.company AS customer_company, co.name AS company_name
@@ -239,6 +362,12 @@ $assemblyLabel = $assemblyTypes[$offer['assembly_type']] ?? 'Bilinmiyor';
                 <a href="quotations.php" class="btn btn-secondary btn-sm">Geri Dön</a>
                 <a href="quotation_edit.php?id=<?= e((string)$offer['id']) ?>" class="btn btn-primary btn-sm">Düzenle</a>
                 <?php if ($role === 'admin'): ?>
+                    <form method="post" class="d-inline">
+                        <input type="hidden" name="action" value="optimize">
+                        <input type="hidden" name="id" value="<?= e((string)$offer['id']) ?>">
+                        <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
+                        <button type="submit" class="btn btn-success btn-sm">Optimize</button>
+                    </form>
                     <form method="post" class="d-inline" onsubmit="return confirm('Bu teklifi silmek istediğinize emin misiniz?');">
                         <input type="hidden" name="action" value="delete">
                         <input type="hidden" name="id" value="<?= e((string)$offer['id']) ?>">

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -68,7 +68,7 @@ if (
         try {
             $pdo->beginTransaction();
 
-            $pStmt = $pdo->prepare('SELECT unit_price, vat_rate FROM products WHERE product_code = :code');
+            $pStmt = $pdo->prepare('SELECT p.unit_price, p.vat_rate, p.weight_per_meter, p.width, p.height, c.unit_type FROM products p LEFT JOIN categories c ON p.category = c.id WHERE p.product_code = :code');
 
             // --- Guillotine systems ---
             $gFetch = $pdo->prepare('SELECT * FROM guillotinesystems WHERE general_offer_id = :id');
@@ -98,7 +98,13 @@ if (
                         if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
                             $unit = (float)$p['unit_price'];
                             $vat  = (float)$p['vat_rate'];
-                            $base += $calcQty * $unit * (1 + $vat / 100);
+                            $unitType = $p['unit_type'];
+                            if ($unitType === 'kg/m') {
+                                $weight = (float)$p['weight_per_meter'];
+                                $base += $calcQty * $weight * $unit * (1 + $vat / 100);
+                            } else {
+                                $base += $calcQty * $unit * (1 + $vat / 100);
+                            }
                         }
                     }
                 }
@@ -140,7 +146,13 @@ if (
                         if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
                             $unit = (float)$p['unit_price'];
                             $vat  = (float)$p['vat_rate'];
-                            $base += $calcQty * $unit * (1 + $vat / 100);
+                            $unitType = $p['unit_type'];
+                            if ($unitType === 'kg/m') {
+                                $weight = (float)$p['weight_per_meter'];
+                                $base += $calcQty * $weight * $unit * (1 + $vat / 100);
+                            } else {
+                                $base += $calcQty * $unit * (1 + $vat / 100);
+                            }
                         }
                     }
                 }

--- a/rules.php
+++ b/rules.php
@@ -1,0 +1,59 @@
+<?php
+return [
+    'guillotine' => [
+        [
+            'match' => function(array $row): bool {
+                return ($row['system_type'] ?? '') === 'Guillotine';
+            },
+            'products' => [
+                [
+                    'code' => 'G_FRAME',
+                    'qty' => function(array $r) {
+                        $width = (float)($r['width'] ?? 0);
+                        $height = (float)($r['height'] ?? 0);
+                        $qty = (int)($r['quantity'] ?? 0);
+                        return ($width / 1000) * ($height / 1000) * $qty; // m² based
+                    }
+                ],
+                [
+                    'code' => 'G_MOTOR',
+                    'qty' => function(array $r) {
+                        return ($r['motor_system'] ?? '') === 'motorlu' ? (int)($r['quantity'] ?? 0) : 0;
+                    }
+                ],
+                [
+                    'code' => 'G_REMOTE',
+                    'qty' => function(array $r) {
+                        return (int)($r['remote_quantity'] ?? 0);
+                    }
+                ],
+                [
+                    'code' => 'G_GLASS_CLR',
+                    'qty' => function(array $r) {
+                        $width = (float)($r['width'] ?? 0);
+                        $height = (float)($r['height'] ?? 0);
+                        $qty = (int)($r['quantity'] ?? 0);
+                        return ($r['glass_type'] ?? '') === 'clear' ? ($width / 1000) * ($height / 1000) * $qty : 0;
+                    }
+                ],
+            ],
+        ],
+    ],
+    'sliding' => [
+        [
+            'match' => function(array $row): bool {
+                return ($row['system_type'] ?? '') === 'Sliding';
+            },
+            'products' => [
+                [
+                    'code' => 'S_FRAME',
+                    'qty' => function(array $r) {
+                        $width = (float)($r['width'] ?? 0);
+                        $qty = (int)($r['quantity'] ?? 0);
+                        return ($width / 1000) * $qty;
+                    }
+                ],
+            ],
+        ],
+    ],
+];

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Anamakine: 127.0.0.1
--- Üretim Zamanı: 09 Ağu 2025, 08:37:29
+-- Üretim Zamanı: 11 Ağu 2025, 14:05:42
 -- Sunucu sürümü: 10.4.32-MariaDB
 -- PHP Sürümü: 8.2.12
 
@@ -20,6 +20,18 @@ SET time_zone = "+00:00";
 --
 -- Veritabanı: `teklifpro`
 --
+
+-- --------------------------------------------------------
+
+--
+-- Tablo için tablo yapısı `categories`
+--
+
+CREATE TABLE `categories` (
+  `id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `unit_type` enum('kg/m','adet','m','m²') NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
 -- --------------------------------------------------------
 
@@ -52,6 +64,14 @@ CREATE TABLE `customers` (
   `address` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
+--
+-- Tablo döküm verisi `customers`
+--
+
+INSERT INTO `customers` (`id`, `first_name`, `last_name`, `company`, `email`, `phone`, `address`) VALUES
+(1, 'Hakan Berke', 'İÇELLİOĞLU', NULL, 'hakanicellioglu@gmail.com', '05466017490', 'Mustafa Şimşek Bulvarı Alpaslan Mahallesi Esen Apartmanı 112/ 37'),
+(2, 'Hakan', 'İÇELLİOĞLU', NULL, 'hakanicellioglu@gmail.com', '05466017490', 'Yahya Kemal caddesi Yılmaz apartmanı 21/6');
+
 -- --------------------------------------------------------
 
 --
@@ -76,6 +96,13 @@ CREATE TABLE `generaloffers` (
   `total_amount` decimal(15,2) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
+--
+-- Tablo döküm verisi `generaloffers`
+--
+
+INSERT INTO `generaloffers` (`id`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`) VALUES
+(2, 2, NULL, '2025-08-11', 'demonte', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00);
+
 -- --------------------------------------------------------
 
 --
@@ -94,22 +121,21 @@ CREATE TABLE `guillotinesystems` (
   `ral_code` varchar(50) DEFAULT NULL,
   `glass_type` varchar(100) DEFAULT NULL,
   `glass_color` varchar(50) DEFAULT NULL,
+  `profit_margin` decimal(5,2) DEFAULT NULL,
   `profit_rate` decimal(5,2) DEFAULT NULL,
   `profit_amount` decimal(10,2) DEFAULT NULL,
   `total_amount` decimal(15,2) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
--- --------------------------------------------------------
-
 --
--- Tablo için tablo yapısı `categories`
+-- Tablo döküm verisi `guillotinesystems`
 --
 
-CREATE TABLE `categories` (
-  `id` int(11) NOT NULL,
-  `name` varchar(255) NOT NULL,
-  `unit_type` varchar(50) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
+INSERT INTO `guillotinesystems` (`id`, `general_offer_id`, `system_type`, `width`, `height`, `quantity`, `motor_system`, `remote_quantity`, `ral_code`, `glass_type`, `glass_color`, `profit_margin`, `profit_rate`, `profit_amount`, `total_amount`) VALUES
+(2, 2, 'Guillotine', 1000.00, 1000.00, 1, 'Somfy', 1, '7016', 'Isıcam', 'Şeffaf', 30.00, NULL, 0.00, 0.00),
+(3, 2, 'Guillotine', 1000.00, 1000.00, 1, 'Somfy', 1, '7016', 'Isıcam', 'Şeffaf', 30.00, NULL, 0.00, 0.00),
+(4, 2, 'Guillotine', 1000.00, 1000.00, 1, 'Somfy', 1, '7016', 'Isıcam', 'Şeffaf', 30.00, NULL, 0.00, 0.00),
+(5, 2, 'Guillotine', 1000.00, 1000.00, 1, 'Somfy', 1, '7016', 'Isıcam', 'Şeffaf', 30.00, NULL, 0.00, 0.00);
 
 -- --------------------------------------------------------
 
@@ -121,7 +147,7 @@ CREATE TABLE `products` (
   `id` int(11) NOT NULL,
   `product_code` varchar(100) NOT NULL,
   `name` varchar(255) NOT NULL,
-  `category` int(11) DEFAULT NULL,
+  `category` varchar(100) DEFAULT NULL,
   `unit` varchar(50) DEFAULT NULL,
   `color` varchar(50) DEFAULT NULL,
   `image_data` longblob DEFAULT NULL,
@@ -129,11 +155,17 @@ CREATE TABLE `products` (
   `image_url` text DEFAULT NULL,
   `description` text DEFAULT NULL,
   `unit_price` decimal(10,2) DEFAULT NULL,
+  `weight_per_meter` decimal(10,3) DEFAULT NULL,
   `vat_rate` decimal(5,2) DEFAULT NULL,
-  `weight_per_meter` decimal(10,4) DEFAULT NULL,
-  `width` decimal(10,2) DEFAULT NULL,
-  `height` decimal(10,2) DEFAULT NULL
+  `category_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
+
+--
+-- Tablo döküm verisi `products`
+--
+
+INSERT INTO `products` (`id`, `product_code`, `name`, `category`, `unit`, `color`, `image_data`, `image_mime`, `image_url`, `description`, `unit_price`, `weight_per_meter`, `vat_rate`, `category_id`) VALUES
+(5, 'PRD-01', 'Tek Cam Çıtası', 'test', 'metre', '7016 Mat', NULL, NULL, NULL, NULL, 1000.00, NULL, 20.00, NULL);
 
 -- --------------------------------------------------------
 
@@ -143,8 +175,16 @@ CREATE TABLE `products` (
 
 CREATE TABLE `roles` (
   `id` int(11) NOT NULL,
-  `name` varchar(255) NOT NULL
+  `name` varchar(255) NOT NULL DEFAULT 'user'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
+
+--
+-- Tablo döküm verisi `roles`
+--
+
+INSERT INTO `roles` (`id`, `name`) VALUES
+(1, 'admin'),
+(2, 'user');
 
 -- --------------------------------------------------------
 
@@ -183,6 +223,20 @@ CREATE TABLE `themes` (
   `secondary_color` varchar(20) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
+--
+-- Tablo döküm verisi `themes`
+--
+
+INSERT INTO `themes` (`id`, `user_id`, `theme`, `primary_color`, `secondary_color`) VALUES
+(1, 1, NULL, '#0080ff', NULL),
+(2, 2, NULL, '#0080ff', NULL),
+(3, 2, NULL, '#0080ff', NULL),
+(4, 2, NULL, '#ff0000', NULL),
+(5, 2, NULL, '#ffffff', NULL),
+(6, 2, NULL, '#ffffff', NULL),
+(7, 2, NULL, '#c2c2c2', NULL),
+(8, 2, NULL, '#ffae00', NULL);
+
 -- --------------------------------------------------------
 
 --
@@ -202,8 +256,22 @@ CREATE TABLE `users` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
 --
+-- Tablo döküm verisi `users`
+--
+
+INSERT INTO `users` (`id`, `first_name`, `last_name`, `username`, `password`, `email`, `created_at`, `status`, `role_id`) VALUES
+(1, 'Hakan Berke', 'İÇELLİOĞLU', 'test', '$2y$10$DUUBza1Cb8jX5W3KOz86Dun5wnStXbNy4FKJfYSwp61VsR3vbtpx.', 'hakanicellioglu@gmail.com', '2025-08-08 15:48:40', 'active', 2),
+(2, 'Hakan Berke', 'İÇELLİOĞLU', 'berkeicellioglu', '$2y$10$HhrRodC3PPyYQnoEZjBBCuDNUMmIChruGAILddp8HoKPeJqvkABO.', 'berkeicellioglu@gmail.com', '2025-08-09 12:41:09', 'active', 1);
+
+--
 -- Dökümü yapılmış tablolar için indeksler
 --
+
+--
+-- Tablo için indeksler `categories`
+--
+ALTER TABLE `categories`
+  ADD PRIMARY KEY (`id`);
 
 --
 -- Tablo için indeksler `company`
@@ -236,7 +304,8 @@ ALTER TABLE `guillotinesystems`
 -- Tablo için indeksler `products`
 --
 ALTER TABLE `products`
-  ADD PRIMARY KEY (`id`);
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `category_id` (`category_id`);
 
 --
 -- Tablo için indeksler `roles`
@@ -271,6 +340,12 @@ ALTER TABLE `users`
 --
 
 --
+-- Tablo için AUTO_INCREMENT değeri `categories`
+--
+ALTER TABLE `categories`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- Tablo için AUTO_INCREMENT değeri `company`
 --
 ALTER TABLE `company`
@@ -280,31 +355,31 @@ ALTER TABLE `company`
 -- Tablo için AUTO_INCREMENT değeri `customers`
 --
 ALTER TABLE `customers`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
 
 --
 -- Tablo için AUTO_INCREMENT değeri `generaloffers`
 --
 ALTER TABLE `generaloffers`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
 
 --
 -- Tablo için AUTO_INCREMENT değeri `guillotinesystems`
 --
 ALTER TABLE `guillotinesystems`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
 -- Tablo için AUTO_INCREMENT değeri `products`
 --
 ALTER TABLE `products`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
 -- Tablo için AUTO_INCREMENT değeri `roles`
 --
 ALTER TABLE `roles`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
 
 --
 -- Tablo için AUTO_INCREMENT değeri `slidingsystems`
@@ -316,13 +391,13 @@ ALTER TABLE `slidingsystems`
 -- Tablo için AUTO_INCREMENT değeri `themes`
 --
 ALTER TABLE `themes`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=9;
 
 --
 -- Tablo için AUTO_INCREMENT değeri `users`
 --
 ALTER TABLE `users`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
 
 --
 -- Dökümü yapılmış tablolar için kısıtlamalar
@@ -340,6 +415,12 @@ ALTER TABLE `generaloffers`
 --
 ALTER TABLE `guillotinesystems`
   ADD CONSTRAINT `guillotinesystems_ibfk_1` FOREIGN KEY (`general_offer_id`) REFERENCES `generaloffers` (`id`);
+
+--
+-- Tablo kısıtlamaları `products`
+--
+ALTER TABLE `products`
+  ADD CONSTRAINT `products_ibfk_1` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`);
 
 --
 -- Tablo kısıtlamaları `slidingsystems`

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -102,6 +102,18 @@ CREATE TABLE `guillotinesystems` (
 -- --------------------------------------------------------
 
 --
+-- Tablo için tablo yapısı `categories`
+--
+
+CREATE TABLE `categories` (
+  `id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `unit_type` varchar(50) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Tablo için tablo yapısı `products`
 --
 
@@ -109,7 +121,7 @@ CREATE TABLE `products` (
   `id` int(11) NOT NULL,
   `product_code` varchar(100) NOT NULL,
   `name` varchar(255) NOT NULL,
-  `category` varchar(100) DEFAULT NULL,
+  `category` int(11) DEFAULT NULL,
   `unit` varchar(50) DEFAULT NULL,
   `color` varchar(50) DEFAULT NULL,
   `image_data` longblob DEFAULT NULL,
@@ -117,7 +129,10 @@ CREATE TABLE `products` (
   `image_url` text DEFAULT NULL,
   `description` text DEFAULT NULL,
   `unit_price` decimal(10,2) DEFAULT NULL,
-  `vat_rate` decimal(5,2) DEFAULT NULL
+  `vat_rate` decimal(5,2) DEFAULT NULL,
+  `weight_per_meter` decimal(10,4) DEFAULT NULL,
+  `width` decimal(10,2) DEFAULT NULL,
+  `height` decimal(10,2) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- add configurable rules in `rules.php` to map system inputs to product codes and quantity formulas
- introduce admin-only `optimize` action in `quotation_view.php` to recalc guillotine and sliding totals within a DB transaction
- add header button to trigger optimization
- create `guillotine_optimization.php` to calculate part measurements, weights, and costs from user inputs using database-driven product data

## Testing
- `php -l rules.php`
- `php -l quotation_view.php`
- `php -l guillotine_optimization.php`


------
https://chatgpt.com/codex/tasks/task_e_6899c7dcbd608328b85d1162654771a5