### PR TITLE
Add company_name support to customer management

### DIFF
--- a/customer.php
+++ b/customer.php
@@ -30,12 +30,12 @@ try {
     $hasDate = false;
 }
 
-$sql = 'SELECT id, first_name, last_name, email, phone';
+$sql = 'SELECT id, first_name, last_name, company_name, email, phone';
 $sql .= $hasDate ? ', created_at AS registration_date' : ', NULL AS registration_date';
 $sql .= ' FROM customers';
 $params = [];
 if ($search !== '') {
-    $sql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR email LIKE :term OR phone LIKE :term';
+    $sql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR company_name LIKE :term OR email LIKE :term OR phone LIKE :term';
     $params['term'] = "%$search%";
 }
 $sql .= ' ORDER BY id DESC LIMIT :limit OFFSET :offset';
@@ -51,7 +51,7 @@ $customers = $stmt->fetchAll();
 // Count total for pagination
 $countSql = 'SELECT COUNT(*) FROM customers';
 if ($search !== '') {
-    $countSql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR email LIKE :term OR phone LIKE :term';
+    $countSql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR company_name LIKE :term OR email LIKE :term OR phone LIKE :term';
 }
 $countStmt = $pdo->prepare($countSql);
 if ($search !== '') {
@@ -98,6 +98,7 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
                     <thead>
                         <tr>
                             <th>İsim</th>
+                            <th>Company Name</th>
                             <th>Email</th>
                             <th>Telefon Numarası</th>
                             <th>Kayıt Tarihi</th>
@@ -109,6 +110,7 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
                             <?php foreach ($customers as $cust): ?>
                                 <tr>
                                     <td><?= htmlspecialchars(trim(($cust['first_name'] ?? '') . ' ' . ($cust['last_name'] ?? '')), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td><?= htmlspecialchars($cust['company_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
                                     <td><?= htmlspecialchars($cust['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
                                     <td><?= htmlspecialchars($cust['phone'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
                                     <td><?= htmlspecialchars($cust['registration_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
@@ -123,7 +125,7 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
                             <?php endforeach; ?>
                         <?php else: ?>
                             <tr>
-                                <td colspan="5" class="text-center text-muted">Müşteri bulunamadı.</td>
+                                <td colspan="6" class="text-center text-muted">Müşteri bulunamadı.</td>
                             </tr>
                         <?php endif; ?>
                     </tbody>

--- a/customers/add.php
+++ b/customers/add.php
@@ -9,13 +9,15 @@ $last_name = '';
 $email = '';
 $phone = '';
 $address = '';
+$company_name = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $first_name = trim($_POST['first_name'] ?? '');
     $last_name  = trim($_POST['last_name'] ?? '');
-    $email      = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL);
-    $phone      = trim($_POST['phone'] ?? '');
-    $address    = trim($_POST['address'] ?? '');
+    $email        = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL);
+    $phone        = trim($_POST['phone'] ?? '');
+    $address      = trim($_POST['address'] ?? '');
+    $company_name = trim($_POST['company_name'] ?? '');
 
     if ($first_name === '') {
         $errors[] = 'First name is required.';
@@ -35,16 +37,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!$errors) {
         try {
-            $stmt = $pdo->prepare('INSERT INTO customers (first_name, last_name, email, phone, address) VALUES (:first_name, :last_name, :email, :phone, :address)');
+            $stmt = $pdo->prepare('INSERT INTO customers (first_name, last_name, company_name, email, phone, address) VALUES (:first_name, :last_name, :company_name, :email, :phone, :address)');
             $stmt->execute([
                 'first_name' => $first_name,
                 'last_name'  => $last_name,
+                'company_name' => $company_name,
                 'email'      => $email,
                 'phone'      => $phone,
                 'address'    => $address,
             ]);
             $success = 'Customer added successfully.';
-            $first_name = $last_name = $email = $phone = $address = '';
+            $first_name = $last_name = $company_name = $email = $phone = $address = '';
         } catch (Exception $e) {
             $errors[] = 'Failed to add customer.';
         }
@@ -84,6 +87,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         <input type='text' class='form-control' id='last_name' name='last_name' value='<?= htmlspecialchars($last_name, ENT_QUOTES, 'UTF-8'); ?>' required>
                         <div class='invalid-feedback'>Lütfen soyisminizi girin</div>
                     </div>
+                </div>
+                <div class='mb-3'>
+                    <label for='company_name' class='form-label'>Company Name</label>
+                    <input type='text' class='form-control' id='company_name' name='company_name' value='<?= htmlspecialchars($company_name, ENT_QUOTES, 'UTF-8'); ?>'>
                 </div>
                 <div class='mb-3'>
                     <label for='email' class='form-label'>Email</label>

--- a/customers/edit.php
+++ b/customers/edit.php
@@ -9,7 +9,7 @@ if (!$id) {
 }
 
 // Fetch existing customer data
-$stmt = $pdo->prepare('SELECT first_name, last_name, email, phone, address FROM customers WHERE id = :id');
+$stmt = $pdo->prepare('SELECT first_name, last_name, company_name, email, phone, address FROM customers WHERE id = :id');
 $stmt->execute(['id' => $id]);
 $customer = $stmt->fetch();
 
@@ -24,9 +24,10 @@ $success = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $firstName = trim(filter_input(INPUT_POST, 'first_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
     $lastName  = trim(filter_input(INPUT_POST, 'last_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-    $email     = trim(filter_input(INPUT_POST, 'email', FILTER_SANITIZE_EMAIL));
-    $phone     = trim(filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-    $address   = trim(filter_input(INPUT_POST, 'address', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
+    $email       = trim(filter_input(INPUT_POST, 'email', FILTER_SANITIZE_EMAIL));
+    $phone       = trim(filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
+    $address     = trim(filter_input(INPUT_POST, 'address', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
+    $companyName = trim(filter_input(INPUT_POST, 'company_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
 
     if ($firstName === '') {
         $errors[] = 'First name is required.';
@@ -46,22 +47,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!$errors) {
         try {
-            $stmt = $pdo->prepare('UPDATE customers SET first_name = :first_name, last_name = :last_name, email = :email, phone = :phone, address = :address WHERE id = :id');
+            $stmt = $pdo->prepare('UPDATE customers SET first_name = :first_name, last_name = :last_name, company_name = :company_name, email = :email, phone = :phone, address = :address WHERE id = :id');
             $stmt->execute([
-                'first_name' => $firstName,
-                'last_name'  => $lastName,
-                'email'      => $email,
-                'phone'      => $phone,
-                'address'    => $address,
-                'id'         => $id,
+                'first_name'   => $firstName,
+                'last_name'    => $lastName,
+                'company_name' => $companyName,
+                'email'        => $email,
+                'phone'        => $phone,
+                'address'      => $address,
+                'id'           => $id,
             ]);
             $success = 'Customer updated successfully.';
             $customer = [
-                'first_name' => $firstName,
-                'last_name'  => $lastName,
-                'email'      => $email,
-                'phone'      => $phone,
-                'address'    => $address,
+                'first_name'   => $firstName,
+                'last_name'    => $lastName,
+                'company_name' => $companyName,
+                'email'        => $email,
+                'phone'        => $phone,
+                'address'      => $address,
             ];
         } catch (Exception $e) {
             $errors[] = 'Failed to update customer.';
@@ -96,6 +99,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <div class="mb-3">
                     <label for="last_name" class="form-label">Soyisim</label>
                     <input type="text" class="form-control" id="last_name" name="last_name" required value="<?= htmlspecialchars($customer['last_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+                <div class="mb-3">
+                    <label for="company_name" class="form-label">Company Name</label>
+                    <input type="text" class="form-control" id="company_name" name="company_name" value="<?= htmlspecialchars($customer['company_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 </div>
                 <div class="mb-3">
                     <label for="email" class="form-label">Email</label>


### PR DESCRIPTION
## Summary
- Add optional company_name field to customer add and edit forms
- Store and update company_name in database queries
- Show company names in customer list and include in search

## Testing
- `php -l customer.php`
- `php -l customers/add.php`
- `php -l customers/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_689b3d0310048328a7c2e791882add1c