### PR TITLE
Ensure UTF-8 handling and support company names

### DIFF
--- a/config.php
+++ b/config.php
@@ -16,6 +16,7 @@ try {
             PDO::ATTR_EMULATE_PREPARES => false,
         ]
     );
+    $pdo->exec('SET NAMES utf8mb4 COLLATE utf8mb4_turkish_ci');
 } catch (PDOException $e) {
     // In production, consider logging the error instead of displaying it
     die('Database connection failed: ' . $e->getMessage());

--- a/customer.php
+++ b/customer.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/header.php';
+$pdo->exec('SET NAMES utf8mb4 COLLATE utf8mb4_turkish_ci');
 
 // Handle deletion
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
@@ -98,7 +99,7 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
                     <thead>
                         <tr>
                             <th>İsim</th>
-                            <th>Şirket</th>
+                            <th>Company Name</th>
                             <th>Email</th>
                             <th>Telefon Numarası</th>
                             <th>Kayıt Tarihi</th>

--- a/customers/add.php
+++ b/customers/add.php
@@ -89,7 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     </div>
                 </div>
                 <div class='mb-3'>
-                    <label for='company_name' class='form-label'>Şirket</label>
+                    <label for='company_name' class='form-label'>Company Name</label>
                     <input type='text' class='form-control' id='company_name' name='company_name' value='<?= htmlspecialchars($company_name, ENT_QUOTES, 'UTF-8'); ?>'>
                 </div>
                 <div class='mb-3'>

--- a/customers/edit.php
+++ b/customers/edit.php
@@ -22,12 +22,12 @@ $errors = [];
 $success = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $firstName = trim(filter_input(INPUT_POST, 'first_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-    $lastName  = trim(filter_input(INPUT_POST, 'last_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-    $email       = trim(filter_input(INPUT_POST, 'email', FILTER_SANITIZE_EMAIL));
-    $phone       = trim(filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-    $address     = trim(filter_input(INPUT_POST, 'address', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-    $companyName = trim(filter_input(INPUT_POST, 'company_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS));
+    $firstName   = trim($_POST['first_name'] ?? '');
+    $lastName    = trim($_POST['last_name'] ?? '');
+    $email       = trim($_POST['email'] ?? '');
+    $phone       = trim($_POST['phone'] ?? '');
+    $address     = trim($_POST['address'] ?? '');
+    $companyName = trim($_POST['company_name'] ?? '');
 
     if ($firstName === '') {
         $errors[] = 'First name is required.';
@@ -101,7 +101,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <input type="text" class="form-control" id="last_name" name="last_name" required value="<?= htmlspecialchars($customer['last_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 </div>
                 <div class="mb-3">
-                    <label for="company_name" class="form-label">Şirket</label>
+                    <label for="company_name" class="form-label">Company Name</label>
                     <input type="text" class="form-control" id="company_name" name="company_name" value="<?= htmlspecialchars($customer['company_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 </div>
                 <div class="mb-3">

--- a/header.php
+++ b/header.php
@@ -42,7 +42,7 @@ if ($u) {
 <html lang="en">
 
 <head>
-    <meta charset="utf-8">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <title>TeklifPro</title>


### PR DESCRIPTION
## Summary
- enforce UTF-8 with Turkish collation on the PDO connection
- expose new Company Name field in customer forms and list with proper escaping
- remove HTML sanitization before database writes

## Testing
- `php -l config.php header.php customer.php customers/add.php customers/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_689b3f6898688328bec4b8414a43c4c2