### PR TITLE
Refactor PHP views with Bootstrap layout and components

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -1,0 +1,59 @@
+:root {
+  --color-bg: #f8f9fa;
+  --color-text: #212529;
+  --color-primary: #0d6efd;
+  --color-secondary: #6c757d;
+  --color-danger: #dc3545;
+  --radius: .5rem;
+  --shadow: 0 .125rem .25rem rgba(0,0,0,.075);
+  --spacer-1: .5rem; /*8px*/
+  --spacer-2: .75rem; /*12px*/
+  --spacer-3: 1rem; /*16px*/
+  --spacer-4: 1.5rem; /*24px*/
+}
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+body.dark {
+  --color-bg: #212529;
+  --color-text: #f8f9fa;
+  --color-primary: #0d6efd;
+  --color-secondary: #adb5bd;
+  --color-danger: #f03e3e;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+.btn-icon > i { margin-right: .5rem; }
+.skeleton {
+  animation: skeleton-loading 1s linear infinite alternate;
+  background: #e2e5e7;
+  border-radius: var(--radius);
+  color: transparent;
+}
+body.dark .skeleton { background: #495057; }
+@keyframes skeleton-loading {
+  from { opacity:.6; }
+  to { opacity:1; }
+}
+.visually-hidden-focusable:not(:focus):not(:focus-within) {
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
+.visually-hidden-focusable:focus,
+.visually-hidden-focusable:focus-within {
+  position:static;
+  width:auto;
+  height:auto;
+  margin:0;
+  overflow:visible;
+  clip:auto;
+  white-space:normal;
+}

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('themeToggle');
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark') document.body.classList.add('dark');
+  toggle?.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+  });
+
+  const confirmModalEl = document.getElementById('confirmModal');
+  const confirmModal = confirmModalEl ? new bootstrap.Modal(confirmModalEl) : null;
+  let confirmAction = null;
+  document.querySelectorAll('[data-confirm]').forEach(el => {
+    el.addEventListener('click', e => {
+      e.preventDefault();
+      const msg = el.getAttribute('data-confirm');
+      if (confirmModalEl) {
+        confirmModalEl.querySelector('.modal-body').textContent = msg || '';
+        confirmModal.show();
+        confirmAction = () => {
+          const href = el.getAttribute('href');
+          if (href) {
+            window.location = href;
+          } else {
+            el.closest('form')?.submit();
+          }
+        };
+      } else if (msg && !window.confirm(msg)) {
+        return;
+      } else {
+        el.closest('form')?.submit();
+      }
+    });
+  });
+  document.getElementById('confirmYes')?.addEventListener('click', () => {
+    confirmModal?.hide();
+    confirmAction && confirmAction();
+  });
+
+  window.showToast = function (msg, type = 'success') {
+    const container = document.getElementById('toastContainer');
+    if (!container) return;
+    const toast = document.createElement('div');
+    toast.className = `toast align-items-center text-bg-${type} border-0`;
+    toast.setAttribute('role', 'alert');
+    toast.innerHTML = `<div class="d-flex"><div class="toast-body">${msg}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>`;
+    container.appendChild(toast);
+    new bootstrap.Toast(toast).show();
+  };
+
+  document.querySelectorAll('form').forEach(form => {
+    form.addEventListener('submit', () => {
+      form.querySelectorAll('button[type=submit]').forEach(btn => {
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>Kaydediliyor';
+      });
+    }, { once: true });
+  });
+});

--- a/components/data_table.php
+++ b/components/data_table.php
@@ -1,0 +1,23 @@
+<?php
+function data_table_start(array $headers): void {
+?>
+<div class="table-responsive">
+<table class="table table-hover align-middle">
+  <thead class="table-light sticky-top">
+    <tr>
+      <?php foreach ($headers as $h): ?>
+        <th scope="col"><?= htmlspecialchars($h, ENT_QUOTES, 'UTF-8'); ?></th>
+      <?php endforeach; ?>
+    </tr>
+  </thead>
+  <tbody>
+<?php
+}
+
+function data_table_end(): void {
+?>
+  </tbody>
+</table>
+</div>
+<?php
+}

--- a/components/form_group.php
+++ b/components/form_group.php
@@ -1,0 +1,11 @@
+<?php
+function form_group(string $id, string $label, string $inputHtml, string $help = '', string $error = ''): void {
+?>
+<div class="mb-3">
+  <label for="<?= htmlspecialchars($id, ENT_QUOTES, 'UTF-8'); ?>" class="form-label"><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></label>
+  <?= $inputHtml ?>
+  <?php if ($help): ?><div class="form-text"><?= htmlspecialchars($help, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
+  <?php if ($error): ?><div class="invalid-feedback d-block"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
+</div>
+<?php
+}

--- a/components/page_header.php
+++ b/components/page_header.php
@@ -1,0 +1,9 @@
+<?php
+function page_header(string $title, string $actions = ''): void {
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h4 mb-0"><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></h1>
+  <div><?= $actions ?></div>
+</div>
+<?php
+}

--- a/components/stat_card.php
+++ b/components/stat_card.php
@@ -1,0 +1,14 @@
+<?php
+function stat_card(string $icon, string $title, string $value): void {
+?>
+<div class="col-md-4">
+  <div class="card text-center h-100 shadow-sm">
+    <div class="card-body">
+      <i class="bi <?= htmlspecialchars($icon, ENT_QUOTES, 'UTF-8'); ?> fs-1" aria-hidden="true"></i>
+      <h5 class="mt-2"><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></h5>
+      <p class="display-6 mb-0"><?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?></p>
+    </div>
+  </div>
+</div>
+<?php
+}

--- a/customer.php
+++ b/customer.php
@@ -1,22 +1,21 @@
 <?php
 require __DIR__ . '/header.php';
+require __DIR__ . '/components/page_header.php';
+require __DIR__ . '/components/data_table.php';
 $pdo->exec('SET NAMES utf8mb4 COLLATE utf8mb4_turkish_ci');
 
-// Handle deletion
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
     $deleteId = (int)($_POST['delete_id'] ?? 0);
     if ($deleteId > 0) {
         try {
             $stmt = $pdo->prepare('DELETE FROM customers WHERE id = :id');
             $stmt->execute(['id' => $deleteId]);
-            header('Location: customer?success=' . urlencode('Customer deleted successfully.'));
+            header('Location: customer?success=' . urlencode('Müşteri silindi.'));
             exit;
         } catch (Exception $e) {
-            $error = 'Failed to delete customer.';
+            $error = 'Silme başarısız.';
         }
-    } else {
-        $error = 'Invalid customer ID.';
-    }
+    } else { $error = 'Geçersiz müşteri ID.'; }
 }
 
 $search = trim(filter_input(INPUT_GET, 'search', FILTER_SANITIZE_SPECIAL_CHARS) ?? '');
@@ -24,13 +23,7 @@ $page = max(1, (int)($_GET['page'] ?? 1));
 $limit = 10;
 $offset = ($page - 1) * $limit;
 
-// Determine if registration date column exists
-try {
-    $hasDate = $pdo->query("SHOW COLUMNS FROM customers LIKE 'created_at'")->rowCount() > 0;
-} catch (Exception $e) {
-    $hasDate = false;
-}
-
+try { $hasDate = $pdo->query("SHOW COLUMNS FROM customers LIKE 'created_at'")->rowCount() > 0; } catch (Exception $e) { $hasDate = false; }
 $sql = 'SELECT id, first_name, last_name, company_name, email, phone';
 $sql .= $hasDate ? ', created_at AS registration_date' : ', NULL AS registration_date';
 $sql .= ' FROM customers';
@@ -41,23 +34,16 @@ if ($search !== '') {
 }
 $sql .= ' ORDER BY id DESC LIMIT :limit OFFSET :offset';
 $stmt = $pdo->prepare($sql);
-foreach ($params as $key => $value) {
-    $stmt->bindValue($key, $value, PDO::PARAM_STR);
-}
+foreach ($params as $key => $value) { $stmt->bindValue($key, $value, PDO::PARAM_STR); }
 $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
 $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
 $stmt->execute();
 $customers = $stmt->fetchAll();
 
-// Count total for pagination
 $countSql = 'SELECT COUNT(*) FROM customers';
-if ($search !== '') {
-    $countSql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR company_name LIKE :term OR email LIKE :term OR phone LIKE :term';
-}
+if ($search !== '') { $countSql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR company_name LIKE :term OR email LIKE :term OR phone LIKE :term'; }
 $countStmt = $pdo->prepare($countSql);
-if ($search !== '') {
-    $countStmt->bindValue(':term', "%$search%", PDO::PARAM_STR);
-}
+if ($search !== '') { $countStmt->bindValue(':term', "%$search%", PDO::PARAM_STR); }
 $countStmt->execute();
 $totalCustomers = (int)$countStmt->fetchColumn();
 $totalPages = (int)ceil($totalCustomers / $limit);
@@ -65,88 +51,42 @@ $totalPages = (int)ceil($totalCustomers / $limit);
 $success = filter_input(INPUT_GET, 'success', FILTER_SANITIZE_SPECIAL_CHARS);
 $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
 ?>
-<div class="container py-4">
-    <div class="card shadow-sm">
-        <div class="card-body">
-            <div class="d-flex justify-content-between align-items-center mb-3">
-                <h4 class="card-title mb-0">Müşteriler</h4>
-                <a href="customers/add" class="btn btn-primary"><i class="bi bi-person-plus me-1" aria-hidden="true"></i>Yeni Müşteri Ekle</a>
-            </div>
-
-            <?php if ($success): ?>
-                <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    <?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-            <?php endif; ?>
-
-            <?php if ($error): ?>
-                <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                    <?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-            <?php endif; ?>
-
-            <form class="mb-3" method="get" novalidate>
-                <div class="input-group">
-                    <input type="text" name="search" class="form-control" placeholder="Search" value="<?= htmlspecialchars($search, ENT_QUOTES, 'UTF-8'); ?>">
-                    <button class="btn btn-outline-secondary" type="submit"><i class="bi bi-search" aria-hidden="true"></i></button>
-                </div>
-            </form>
-
-            <div class="table-responsive">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>İsim</th>
-                            <th>Company Name</th>
-                            <th>Email</th>
-                            <th>Telefon Numarası</th>
-                            <th>Kayıt Tarihi</th>
-                            <th class="text-end">İşlemler</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if ($customers): ?>
-                            <?php foreach ($customers as $cust): ?>
-                                <tr>
-                                    <td><?= htmlspecialchars(trim(($cust['first_name'] ?? '') . ' ' . ($cust['last_name'] ?? '')), ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td><?= htmlspecialchars($cust['company_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td><?= htmlspecialchars($cust['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td><?= htmlspecialchars($cust['phone'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td><?= htmlspecialchars($cust['registration_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td class="text-end">
-                                        <a href="customers/edit?id=<?= (int)$cust['id']; ?>" class="btn btn-sm btn-outline-secondary" title="Edit"><i class="bi bi-pencil" aria-hidden="true"></i></a>
-                                        <form method="post" class="d-inline" onsubmit="return confirm('Delete this customer?');">
-                                            <input type="hidden" name="delete_id" value="<?= (int)$cust['id']; ?>">
-                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete"><i class="bi bi-trash" aria-hidden="true"></i></button>
-                                        </form>
-                                    </td>
-                                </tr>
-                            <?php endforeach; ?>
-                        <?php else: ?>
-                            <tr>
-                                <td colspan="6" class="text-center text-muted">Müşteri bulunamadı.</td>
-                            </tr>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
-            </div>
-
-            <?php if ($totalPages > 1): ?>
-                <nav>
-                    <ul class="pagination justify-content-center">
-                        <?php for ($i = 1; $i <= $totalPages; $i++): ?>
-                            <?php $query = http_build_query(['page' => $i, 'search' => $search]); ?>
-                            <li class="page-item<?= $i === $page ? ' active' : ''; ?>">
-                                <a class="page-link" href="customer?<?= htmlspecialchars($query, ENT_QUOTES, 'UTF-8'); ?>"><?= $i; ?></a>
-                            </li>
-                        <?php endfor; ?>
-                    </ul>
-                </nav>
-            <?php endif; ?>
-        </div>
-    </div>
-</div>
-</body>
-</html>
+<?php page_header('Müşteriler', '<a href="customers/add" class="btn btn-primary btn-icon"><i class="bi bi-person-plus"></i>Yeni Müşteri</a>'); ?>
+<?php if ($success): ?><div class="alert alert-success" role="alert"><?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert alert-danger" role="alert"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
+<form class="mb-3" method="get" role="search">
+  <div class="input-group">
+    <input type="search" name="search" class="form-control" placeholder="Ara" value="<?= htmlspecialchars($search, ENT_QUOTES, 'UTF-8'); ?>">
+    <button class="btn btn-outline-secondary" type="submit"><i class="bi bi-search"></i></button>
+  </div>
+</form>
+<?php data_table_start(['İsim','Şirket','Email','Telefon','Kayıt Tarihi','İşlemler']); ?>
+<?php if ($customers): foreach ($customers as $cust): ?>
+<tr>
+  <td><?= htmlspecialchars(trim(($cust['first_name'] ?? '') . ' ' . ($cust['last_name'] ?? '')), ENT_QUOTES, 'UTF-8'); ?></td>
+  <td><?= htmlspecialchars($cust['company_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+  <td><?= htmlspecialchars($cust['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+  <td><?= htmlspecialchars($cust['phone'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+  <td><?= htmlspecialchars($cust['registration_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+  <td class="text-end">
+    <a href="customers/edit?id=<?= (int)$cust['id']; ?>" class="btn btn-sm btn-outline-secondary" title="Düzenle"><i class="bi bi-pencil"></i></a>
+    <form method="post" class="d-inline">
+      <input type="hidden" name="delete_id" value="<?= (int)$cust['id']; ?>">
+      <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="Bu müşteri silinsin mi?" title="Sil"><i class="bi bi-trash"></i></button>
+    </form>
+  </td>
+</tr>
+<?php endforeach; else: ?>
+<tr><td colspan="6" class="text-center text-muted">Müşteri bulunamadı.</td></tr>
+<?php endif; ?>
+<?php data_table_end(); ?>
+<?php if ($totalPages > 1): ?>
+<nav aria-label="Sayfalar">
+  <ul class="pagination justify-content-center">
+    <?php for ($i = 1; $i <= $totalPages; $i++): $query = http_build_query(['page'=>$i,'search'=>$search]); ?>
+      <li class="page-item<?= $i === $page ? ' active' : ''; ?>"><a class="page-link" href="customer?<?= htmlspecialchars($query, ENT_QUOTES, 'UTF-8'); ?>"><?= $i; ?></a></li>
+    <?php endfor; ?>
+  </ul>
+</nav>
+<?php endif; ?>
+<?php require __DIR__ . '/footer.php'; ?>

--- a/customers/add.php
+++ b/customers/add.php
@@ -1,132 +1,58 @@
 <?php
 require __DIR__ . '/../header.php';
+require __DIR__ . '/../components/page_header.php';
+require __DIR__ . '/../components/form_group.php';
 
 $errors = [];
 $success = null;
-
-$first_name = '';
-$last_name = '';
-$email = '';
-$phone = '';
-$address = '';
-$company_name = '';
+$first_name = $last_name = $email = $phone = $address = $company_name = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $first_name = trim($_POST['first_name'] ?? '');
     $last_name  = trim($_POST['last_name'] ?? '');
-    $email        = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL);
-    $phone        = trim($_POST['phone'] ?? '');
-    $address      = trim($_POST['address'] ?? '');
+    $email      = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL) ?: '';
+    $phone      = trim($_POST['phone'] ?? '');
+    $address    = trim($_POST['address'] ?? '');
     $company_name = trim($_POST['company_name'] ?? '');
 
-    if ($first_name === '') {
-        $errors[] = 'First name is required.';
-    }
-    if ($last_name === '') {
-        $errors[] = 'Last name is required.';
-    }
-    if (!$email) {
-        $errors[] = 'A valid email is required.';
-    }
-    if ($phone === '') {
-        $errors[] = 'Phone number is required.';
-    }
-    if ($address === '') {
-        $errors[] = 'Address is required.';
-    }
+    if ($first_name === '') { $errors['first_name'] = 'İsim zorunludur.'; }
+    if ($last_name === '') { $errors['last_name'] = 'Soyisim zorunludur.'; }
+    if ($email === '') { $errors['email'] = 'Geçerli e-posta girin.'; }
+    if ($phone === '') { $errors['phone'] = 'Telefon numarası zorunludur.'; }
+    if ($address === '') { $errors['address'] = 'Adres zorunludur.'; }
 
     if (!$errors) {
         try {
-            $stmt = $pdo->prepare('INSERT INTO customers (first_name, last_name, company_name, email, phone, address) VALUES (:first_name, :last_name, :company_name, :email, :phone, :address)');
+            $stmt = $pdo->prepare('INSERT INTO customers (first_name, last_name, company_name, email, phone, address) VALUES (:first_name,:last_name,:company_name,:email,:phone,:address)');
             $stmt->execute([
-                'first_name' => $first_name,
-                'last_name'  => $last_name,
-                'company_name' => $company_name,
-                'email'      => $email,
-                'phone'      => $phone,
-                'address'    => $address,
+                'first_name'=>$first_name,
+                'last_name'=>$last_name,
+                'company_name'=>$company_name,
+                'email'=>$email,
+                'phone'=>$phone,
+                'address'=>$address,
             ]);
-            $success = 'Customer added successfully.';
+            $success = 'Müşteri eklendi.';
             $first_name = $last_name = $company_name = $email = $phone = $address = '';
         } catch (Exception $e) {
-            $errors[] = 'Failed to add customer.';
+            $errors['form'] = 'Müşteri eklenemedi.';
         }
     }
 }
 ?>
-<div class='container py-4'>
-    <div class='card shadow-sm'>
-        <div class='card-body'>
-            <h4 class='card-title mb-3'>Müşteri Ekle</h4>
-
-            <?php if ($success): ?>
-                <div class='alert alert-success alert-dismissible fade show' role='alert'>
-                    <?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?>
-                    <button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'></button>
-                </div>
-            <?php endif; ?>
-
-            <?php if ($errors): ?>
-                <div class='alert alert-danger alert-dismissible fade show' role='alert'>
-                    <?php foreach ($errors as $error): ?>
-                        <div><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
-                    <?php endforeach; ?>
-                    <button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'></button>
-                </div>
-            <?php endif; ?>
-
-            <form method='post' class='needs-validation' novalidate>
-                <div class='row'>
-                    <div class='col-md-6 mb-3'>
-                        <label for='first_name' class='form-label'>İsim</label>
-                        <input type='text' class='form-control' id='first_name' name='first_name' value='<?= htmlspecialchars($first_name, ENT_QUOTES, 'UTF-8'); ?>' required>
-                        <div class='invalid-feedback'>Lütfen isminizi girin</div>
-                    </div>
-                    <div class='col-md-6 mb-3'>
-                        <label for='last_name' class='form-label'>Soyisim</label>
-                        <input type='text' class='form-control' id='last_name' name='last_name' value='<?= htmlspecialchars($last_name, ENT_QUOTES, 'UTF-8'); ?>' required>
-                        <div class='invalid-feedback'>Lütfen soyisminizi girin</div>
-                    </div>
-                </div>
-                <div class='mb-3'>
-                    <label for='company_name' class='form-label'>Company Name</label>
-                    <input type='text' class='form-control' id='company_name' name='company_name' value='<?= htmlspecialchars($company_name, ENT_QUOTES, 'UTF-8'); ?>'>
-                </div>
-                <div class='mb-3'>
-                    <label for='email' class='form-label'>Email</label>
-                    <input type='email' class='form-control' id='email' name='email' value='<?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8'); ?>' required>
-                    <div class='invalid-feedback'>Lütfen geçerli bir email adresi girin.</div>
-                </div>
-                <div class='mb-3'>
-                    <label for='phone' class='form-label'>Telefon Numarası</label>
-                    <input type='text' class='form-control' id='phone' name='phone' value='<?= htmlspecialchars($phone, ENT_QUOTES, 'UTF-8'); ?>' required>
-                    <div class='invalid-feedback'>Lütfen bir telefon numarası girin.</div>
-                </div>
-                <div class='mb-3'>
-                    <label for='address' class='form-label'>Address</label>
-                    <textarea class='form-control' id='address' name='address' rows='3' required><?= htmlspecialchars($address, ENT_QUOTES, 'UTF-8'); ?></textarea>
-                    <div class='invalid-feedback'>Lütfen adres girin.</div>
-                </div>
-                <button type='submit' class='btn btn-primary'>Ekle</button>
-                <a href='../customer' class='btn btn-secondary ms-2'>Geri Dön</a>
-            </form>
-        </div>
-    </div>
-</div>
-<script>
-(() => {
-  'use strict';
-  const forms = document.querySelectorAll('.needs-validation');
-  Array.from(forms).forEach(form => {
-    form.addEventListener('submit', event => {
-      if (!form.checkValidity()) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-      form.classList.add('was-validated');
-    }, false);
-  });
-})();
-</script>
-</body>
-</html>
+<?php page_header('Yeni Müşteri'); ?>
+<?php if ($success): ?><div class="alert alert-success" role="alert"><?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
+<?php if ($errors): ?><div class="alert alert-danger" role="alert">Lütfen formu kontrol edin.</div><?php endif; ?>
+<form method="post" novalidate>
+<?php form_group('first_name','İsim',"<input type='text' class='form-control' id='first_name' name='first_name' required value='".htmlspecialchars($first_name,ENT_QUOTES,'UTF-8')."'>",'', $errors['first_name'] ?? ''); ?>
+<?php form_group('last_name','Soyisim',"<input type='text' class='form-control' id='last_name' name='last_name' required value='".htmlspecialchars($last_name,ENT_QUOTES,'UTF-8')."'>",'', $errors['last_name'] ?? ''); ?>
+<?php form_group('company_name','Şirket',"<input type='text' class='form-control' id='company_name' name='company_name' value='".htmlspecialchars($company_name,ENT_QUOTES,'UTF-8')."'>",'Varsa şirket adı'); ?>
+<?php form_group('email','Email',"<input type='email' class='form-control' id='email' name='email' required value='".htmlspecialchars($email,ENT_QUOTES,'UTF-8')."'>",'', $errors['email'] ?? ''); ?>
+<?php form_group('phone','Telefon',"<input type='tel' pattern='^[0-9\s\+\-]{10,}$' class='form-control' id='phone' name='phone' required value='".htmlspecialchars($phone,ENT_QUOTES,'UTF-8')."'>",'Örn: 5xx xxx xx xx', $errors['phone'] ?? ''); ?>
+<?php form_group('address','Adres',"<textarea class='form-control' id='address' name='address' rows='3' required>".htmlspecialchars($address,ENT_QUOTES,'UTF-8')."</textarea>",'', $errors['address'] ?? ''); ?>
+  <div class="d-flex justify-content-end gap-2">
+    <a href="../customer" class="btn btn-secondary">İptal</a>
+    <button type="submit" class="btn btn-primary">Kaydet</button>
+  </div>
+</form>
+<?php require __DIR__ . '/../footer.php'; ?>

--- a/customers/edit.php
+++ b/customers/edit.php
@@ -1,128 +1,56 @@
 <?php
 require __DIR__ . '/../header.php';
+require __DIR__ . '/../components/page_header.php';
+require __DIR__ . '/../components/form_group.php';
 
-// Retrieve and validate customer ID
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-if (!$id) {
-    header('Location: ../customer?error=' . urlencode('Invalid customer ID.'));
-    exit;
-}
-
-// Fetch existing customer data
+if (!$id) { header('Location: ../customer?error=' . urlencode('Geçersiz ID.')); exit; }
 $stmt = $pdo->prepare('SELECT first_name, last_name, company_name, email, phone, address FROM customers WHERE id = :id');
-$stmt->execute(['id' => $id]);
+$stmt->execute(['id'=>$id]);
 $customer = $stmt->fetch();
-
-if (!$customer) {
-    header('Location: ../customer?error=' . urlencode('Customer not found.'));
-    exit;
-}
+if (!$customer) { header('Location: ../customer?error=' . urlencode('Müşteri bulunamadı.')); exit; }
 
 $errors = [];
 $success = '';
-
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $firstName   = trim($_POST['first_name'] ?? '');
-    $lastName    = trim($_POST['last_name'] ?? '');
-    $email       = trim($_POST['email'] ?? '');
-    $phone       = trim($_POST['phone'] ?? '');
-    $address     = trim($_POST['address'] ?? '');
+    $firstName = trim($_POST['first_name'] ?? '');
+    $lastName  = trim($_POST['last_name'] ?? '');
+    $email     = trim($_POST['email'] ?? '');
+    $phone     = trim($_POST['phone'] ?? '');
+    $address   = trim($_POST['address'] ?? '');
     $companyName = trim($_POST['company_name'] ?? '');
-
-    if ($firstName === '') {
-        $errors[] = 'First name is required.';
-    }
-    if ($lastName === '') {
-        $errors[] = 'Last name is required.';
-    }
-    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $errors[] = 'A valid email is required.';
-    }
-    if ($phone === '') {
-        $errors[] = 'Phone number is required.';
-    }
-    if ($address === '') {
-        $errors[] = 'Address is required.';
-    }
-
+    if ($firstName === '') { $errors['first_name']='İsim zorunludur.'; }
+    if ($lastName === '') { $errors['last_name']='Soyisim zorunludur.'; }
+    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) { $errors['email']='Geçerli e-posta girin.'; }
+    if ($phone === '') { $errors['phone']='Telefon zorunludur.'; }
+    if ($address === '') { $errors['address']='Adres zorunludur.'; }
     if (!$errors) {
         try {
-            $stmt = $pdo->prepare('UPDATE customers SET first_name = :first_name, last_name = :last_name, company_name = :company_name, email = :email, phone = :phone, address = :address WHERE id = :id');
-            $stmt->execute([
-                'first_name'   => $firstName,
-                'last_name'    => $lastName,
-                'company_name' => $companyName,
-                'email'        => $email,
-                'phone'        => $phone,
-                'address'      => $address,
-                'id'           => $id,
-            ]);
-            $success = 'Customer updated successfully.';
-            $customer = [
-                'first_name'   => $firstName,
-                'last_name'    => $lastName,
-                'company_name' => $companyName,
-                'email'        => $email,
-                'phone'        => $phone,
-                'address'      => $address,
-            ];
-        } catch (Exception $e) {
-            $errors[] = 'Failed to update customer.';
-        }
+            $stmt = $pdo->prepare('UPDATE customers SET first_name=:first_name,last_name=:last_name,company_name=:company_name,email=:email,phone=:phone,address=:address WHERE id=:id');
+            $stmt->execute(['first_name'=>$firstName,'last_name'=>$lastName,'company_name'=>$companyName,'email'=>$email,'phone'=>$phone,'address'=>$address,'id'=>$id]);
+            $success = 'Müşteri güncellendi.';
+            $customer = ['first_name'=>$firstName,'last_name'=>$lastName,'company_name'=>$companyName,'email'=>$email,'phone'=>$phone,'address'=>$address];
+        } catch (Exception $e) { $errors['form']='Güncellenemedi.'; }
     }
 }
 ?>
-<div class="container py-4">
-    <div class="card shadow-sm">
-        <div class="card-body">
-            <h4 class="card-title mb-3">Müşteriyi Düzenle</h4>
-
-            <?php if ($success): ?>
-                <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    <?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-            <?php endif; ?>
-
-            <?php if ($errors): ?>
-                <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                    <?= htmlspecialchars(implode(' ', $errors), ENT_QUOTES, 'UTF-8'); ?>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-            <?php endif; ?>
-
-            <form method="post" novalidate>
-                <div class="mb-3">
-                    <label for="first_name" class="form-label">İsim</label>
-                    <input type="text" class="form-control" id="first_name" name="first_name" required value="<?= htmlspecialchars($customer['first_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="last_name" class="form-label">Soyisim</label>
-                    <input type="text" class="form-control" id="last_name" name="last_name" required value="<?= htmlspecialchars($customer['last_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="company_name" class="form-label">Company Name</label>
-                    <input type="text" class="form-control" id="company_name" name="company_name" value="<?= htmlspecialchars($customer['company_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="email" class="form-label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email" required value="<?= htmlspecialchars($customer['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="phone" class="form-label">Telefon Numarası</label>
-                    <input type="text" class="form-control" id="phone" name="phone" required value="<?= htmlspecialchars($customer['phone'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="address" class="form-label">Adres</label>
-                    <textarea class="form-control" id="address" name="address" rows="3" required><?= htmlspecialchars($customer['address'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
-                </div>
-                <div class="d-flex justify-content-end">
-                    <a href="../customer" class="btn btn-secondary me-2">İptal</a>
-                    <button type="submit" class="btn btn-primary">Güncelle</button>
-                </div>
-            </form>
-        </div>
-    </div>
+<?php page_header('Müşteriyi Düzenle'); ?>
+<?php if ($success): ?><div class="alert alert-success" role="alert"><?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
+<?php if ($errors): ?><div class="alert alert-danger" role="alert">Lütfen formu kontrol edin.</div><?php endif; ?>
+<form method="post" id="editForm" novalidate>
+<?php form_group('first_name','İsim',"<input type='text' class='form-control' id='first_name' name='first_name' required value='".htmlspecialchars($customer['first_name'] ?? '',ENT_QUOTES,'UTF-8')."'>",'', $errors['first_name'] ?? ''); ?>
+<?php form_group('last_name','Soyisim',"<input type='text' class='form-control' id='last_name' name='last_name' required value='".htmlspecialchars($customer['last_name'] ?? '',ENT_QUOTES,'UTF-8')."'>",'', $errors['last_name'] ?? ''); ?>
+<?php form_group('company_name','Şirket',"<input type='text' class='form-control' id='company_name' name='company_name' value='".htmlspecialchars($customer['company_name'] ?? '',ENT_QUOTES,'UTF-8')."'>",'Varsa şirket adı'); ?>
+<?php form_group('email','Email',"<input type='email' class='form-control' id='email' name='email' required value='".htmlspecialchars($customer['email'] ?? '',ENT_QUOTES,'UTF-8')."'>",'', $errors['email'] ?? ''); ?>
+<?php form_group('phone','Telefon',"<input type='tel' pattern='^[0-9\s\+\-]{10,}$' class='form-control' id='phone' name='phone' required value='".htmlspecialchars($customer['phone'] ?? '',ENT_QUOTES,'UTF-8')."'>",'Örn: 5xx xxx xx xx', $errors['phone'] ?? ''); ?>
+<?php form_group('address','Adres',"<textarea class='form-control' id='address' name='address' rows='3' required>".htmlspecialchars($customer['address'] ?? '',ENT_QUOTES,'UTF-8')."</textarea>",'', $errors['address'] ?? ''); ?>
+</form>
+<form id="deleteForm" method="post" action="../customer" class="d-inline">
+  <input type="hidden" name="delete_id" value="<?= (int)$id; ?>">
+</form>
+<div class="d-flex justify-content-end gap-2">
+  <button form="deleteForm" type="submit" class="btn btn-danger" data-confirm="Bu müşteri silinsin mi?">Sil</button>
+  <a href="../customer" class="btn btn-secondary">İptal</a>
+  <button form="editForm" type="submit" class="btn btn-primary">Kaydet</button>
 </div>
-</body>
-</html>
+<?php require __DIR__ . '/../footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,6 +1,8 @@
 <?php
 require __DIR__ . '/header.php';
-// Fetch logged-in user's name
+require __DIR__ . '/components/page_header.php';
+require __DIR__ . '/components/stat_card.php';
+
 try {
     $stmt = $pdo->prepare('SELECT first_name FROM users WHERE id = :id');
     $stmt->execute(['id' => $_SESSION['user_id']]);
@@ -8,168 +10,71 @@ try {
 } catch (Exception $e) {
     $userName = 'User';
 }
+$currentDate = date('d F Y');
 
-$currentDate = date('l, F j, Y');
-
-// Fetch summary metrics
+try { $totalCustomers = $pdo->query('SELECT COUNT(*) FROM customers')->fetchColumn(); } catch (Exception $e) { $totalCustomers = 0; }
+try { $activeQuotations = $pdo->query('SELECT COUNT(*) FROM generaloffers')->fetchColumn(); } catch (Exception $e) { $activeQuotations = 0; }
 try {
-    $totalCustomers = $pdo->query('SELECT COUNT(*) FROM customers')->fetchColumn();
-} catch (Exception $e) {
-    $totalCustomers = 0;
-}
-
-try {
-    // Assuming every record in generaloffers is an active quotation
-    $activeQuotations = $pdo->query('SELECT COUNT(*) FROM generaloffers')->fetchColumn();
-} catch (Exception $e) {
-    $activeQuotations = 0;
-}
-
-try {
-    $recentStmt = $pdo->query(
-        'SELECT g.offer_date, CONCAT(c.first_name, " ", c.last_name) AS customer '
-            . 'FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id '
-            . 'ORDER BY g.offer_date DESC LIMIT 5'
-    );
+    $recentStmt = $pdo->query('SELECT g.offer_date, CONCAT(c.first_name, " ", c.last_name) AS customer FROM generaloffers g LEFT JOIN customers c ON g.customer_id=c.id ORDER BY g.offer_date DESC LIMIT 5');
     $recentActivity = $recentStmt->fetchAll();
-} catch (Exception $e) {
-    $recentActivity = [];
-}
-
-// Quotation status data for chart
+} catch (Exception $e) { $recentActivity = []; }
 try {
     $statusStmt = $pdo->query('SELECT status, COUNT(*) AS count FROM generaloffers GROUP BY status');
     $statusCounts = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
     $quotationStatuses = [
-        'Active' => (int)($statusCounts['active'] ?? $statusCounts['Active'] ?? $activeQuotations),
-        'Pending' => (int)($statusCounts['pending'] ?? $statusCounts['Pending'] ?? 0),
-        'Closed' => (int)($statusCounts['closed'] ?? $statusCounts['Closed'] ?? 0),
+        'Aktif' => (int)($statusCounts['active'] ?? $statusCounts['Aktif'] ?? $activeQuotations),
+        'Beklemede' => (int)($statusCounts['pending'] ?? $statusCounts['Beklemede'] ?? 0),
+        'Kapalı' => (int)($statusCounts['closed'] ?? $statusCounts['Kapalı'] ?? 0),
     ];
 } catch (Exception $e) {
-    $quotationStatuses = [
-        'Active' => (int)$activeQuotations,
-        'Pending' => 0,
-        'Closed' => 0,
-    ];
+    $quotationStatuses = ['Aktif'=>$activeQuotations,'Beklemede'=>0,'Kapalı'=>0];
 }
-
 ?>
-<div class="container py-4">
-    <!-- Welcome Card -->
-    <div class="card mb-4 shadow-sm">
-        <div class="card-body">
-            <h4 class="card-title mb-1">Hoş geldin, <?= htmlspecialchars($userName, ENT_QUOTES, 'UTF-8'); ?>!</h4>
-            <p class="card-text text-muted mb-0"><?= $currentDate; ?></p>
-        </div>
+<?php page_header('Gösterge Paneli'); ?>
+<div class="mb-4">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h2 class="h5 mb-1">Hoş geldin, <?= htmlspecialchars($userName, ENT_QUOTES, 'UTF-8'); ?></h2>
+      <p class="text-muted mb-0"><?= $currentDate; ?></p>
     </div>
-
-    <!-- Quick Actions -->
-    <div class="row g-3 mb-4 text-center">
-        <div class="col-6 col-md-3">
-            <a href="quotations/create" class="btn btn-primary w-100 h-100 d-flex flex-column justify-content-center align-items-center py-3">
-                <i class="bi bi-plus-circle fs-2 mb-1" aria-hidden="true"></i>
-                <span>Teklif Oluştur</span>
-            </a>
-        </div>
-        <div class="col-6 col-md-3">
-            <a href="customers/add" class="btn btn-outline-primary w-100 h-100 d-flex flex-column justify-content-center align-items-center py-3">
-                <i class="bi bi-person-plus fs-2 mb-1" aria-hidden="true"></i>
-                <span>Müşteri Ekle</span>
-            </a>
-        </div>
-        <div class="col-6 col-md-3">
-            <a href="products" class="btn btn-outline-primary w-100 h-100 d-flex flex-column justify-content-center align-items-center py-3">
-                <i class="bi bi-box-seam fs-2 mb-1" aria-hidden="true"></i>
-                <span>Ürünleri Listele</span>
-            </a>
-        </div>
-        <div class="col-6 col-md-3">
-            <a href="settings" class="btn btn-outline-primary w-100 h-100 d-flex flex-column justify-content-center align-items-center py-3">
-                <i class="bi bi-gear fs-2 mb-1" aria-hidden="true"></i>
-                <span>Ayarlar</span>
-            </a>
-        </div>
+  </div>
+</div>
+<div class="row g-4 mb-4">
+  <?php stat_card('bi-people-fill', 'Müşteri Sayısı', (string)(int)$totalCustomers); ?>
+  <?php stat_card('bi-file-earmark-text', 'Aktif Teklifler', (string)(int)$activeQuotations); ?>
+  <?php stat_card('bi-clock-history', 'Son Güncellemeler', (string)count($recentActivity)); ?>
+</div>
+<div class="row g-4">
+  <div class="col-lg-8">
+    <h2 class="h5 mb-3">Son Aktivite</h2>
+    <div class="table-responsive">
+      <table class="table table-hover">
+        <thead class="table-light sticky-top">
+          <tr><th scope="col">Müşteri</th><th scope="col" class="text-end">Tarih</th></tr>
+        </thead>
+        <tbody>
+        <?php if ($recentActivity): foreach ($recentActivity as $act): ?>
+          <tr>
+            <td><?= htmlspecialchars($act['customer'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td class="text-end"><time datetime="<?= htmlspecialchars($act['offer_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($act['offer_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?></time></td>
+          </tr>
+        <?php endforeach; else: ?>
+          <tr><td colspan="2" class="text-center text-muted">Kayıt bulunamadı.</td></tr>
+        <?php endif; ?>
+        </tbody>
+      </table>
     </div>
-
-    <!-- Summary Cards -->
-    <div class="row g-4 mb-4">
-        <div class="col-md-4">
-            <div class="card h-100 shadow-sm text-center">
-                <div class="card-body">
-                    <i class="bi bi-people-fill text-primary fs-1" aria-hidden="true"></i>
-                    <h5 class="card-title mt-2">Toplam Müşteri</h5>
-                    <p class="display-6 mb-0"><?= (int)$totalCustomers ?></p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card h-100 shadow-sm text-center">
-                <div class="card-body">
-                    <i class="bi bi-file-earmark-text text-success fs-1" aria-hidden="true"></i>
-                    <h5 class="card-title mt-2">Aktif Teklifler</h5>
-                    <p class="display-6 mb-0"><?= (int)$activeQuotations ?></p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card h-100 shadow-sm text-center">
-                <div class="card-body">
-                    <i class="bi bi-clock-history text-secondary fs-1" aria-hidden="true"></i>
-                    <h5 class="card-title mt-2">Son Güncellemeler</h5>
-                    <p class="fs-5 mb-0">Last <?= count($recentActivity) ?> records</p>
-                </div>
-            </div>
-        </div>
+  </div>
+  <div class="col-lg-4">
+    <h2 class="h5 mb-3">Teklif Durumları</h2>
+    <div class="card p-3 shadow-sm">
+      <canvas id="quotationChart" style="min-height:300px"></canvas>
     </div>
-
-    <!-- Recent Activity and Chart -->
-    <div class="row g-4">
-        <div class="col-lg-8">
-            <h4 class="mb-3">Son Güncellemeler</h4>
-            <ul class="list-group">
-                <?php if ($recentActivity): ?>
-                    <?php foreach ($recentActivity as $activity): ?>
-                        <li class="list-group-item d-flex justify-content-between align-items-center">
-                            <span><?= htmlspecialchars($activity['customer'] ?? 'Unknown', ENT_QUOTES, 'UTF-8') ?></span>
-                            <span class="text-muted small"><?= htmlspecialchars($activity['offer_date'] ?? '', ENT_QUOTES, 'UTF-8') ?></span>
-                        </li>
-                    <?php endforeach; ?>
-                <?php else: ?>
-                    <li class="list-group-item text-muted">Son güncelleme bulunamadı.</li>
-                <?php endif; ?>
-            </ul>
-        </div>
-        <div class="col-lg-4">
-            <h4 class="mb-3">Teklif Durumları</h4>
-            <div class="card shadow-sm p-3">
-                <canvas id="quotationChart" style="min-height:300px"></canvas>
-            </div>
-        </div>
-    </div>
+  </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
-    const qCtx = document.getElementById('quotationChart');
-    new Chart(qCtx, {
-        type: 'doughnut',
-        data: {
-            labels: <?= json_encode(array_keys($quotationStatuses)) ?>,
-            datasets: [{
-                data: <?= json_encode(array_values($quotationStatuses)) ?>,
-                backgroundColor: ['#0d6efd', '#ffc107', '#198754'],
-            }]
-        },
-        options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-                legend: {
-                    position: 'bottom'
-                }
-            }
-        }
-    });
+const qCtx = document.getElementById('quotationChart');
+new Chart(qCtx,{type:'doughnut',data:{labels:<?= json_encode(array_keys($quotationStatuses)) ?>,datasets:[{data:<?= json_encode(array_values($quotationStatuses)) ?>,backgroundColor:['#0d6efd','#ffc107','#198754']}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{position:'bottom'}}}});
 </script>
-</body>
-
-</html>
+<?php require __DIR__ . '/footer.php'; ?>

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,27 @@
+  </main>
+  <footer class="container py-4 text-center small text-muted">
+    &copy; <?= date('Y'); ?> TeklifPro
+  </footer>
+
+  <div id="toastContainer" class="toast-container position-fixed bottom-0 end-0 p-3"></div>
+
+  <div class="modal fade" id="confirmModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Onayla</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+        </div>
+        <div class="modal-body"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+          <button type="button" id="confirmYes" class="btn btn-danger">Evet</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/app.js"></script>
+</body>
+</html>

--- a/header.php
+++ b/header.php
@@ -1,81 +1,61 @@
 <?php
-// Initialize or resume a secure session
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
-
-// Redirect unauthenticated users to login page
 if (empty($_SESSION['user_id'])) {
     header('Location: login');
     exit;
 }
-
 require __DIR__ . '/config.php';
 
-// Fetch the current user's role from the database
 $stmt = $pdo->prepare('SELECT r.name FROM users u JOIN roles r ON u.role_id = r.id WHERE u.id = :id');
 $stmt->execute(['id' => $_SESSION['user_id']]);
 $role = $stmt->fetchColumn() ?: 'user';
 
-
-// Fetch logged-in user's display name (first_name + last_name, fallback: username)
-$uStmt = $pdo->prepare('SELECT 
-    TRIM(CONCAT(first_name, " ", last_name)) AS full_name, 
-    username 
-  FROM users 
-  WHERE id = :id');
+$uStmt = $pdo->prepare('SELECT TRIM(CONCAT(first_name, " ", last_name)) AS full_name, username FROM users WHERE id = :id');
 $uStmt->execute(['id' => $_SESSION['user_id']]);
 $u = $uStmt->fetch(PDO::FETCH_ASSOC);
-
-$userName = 'User';
-if ($u) {
-    if (!empty($u['full_name'])) {
-        $userName = $u['full_name'];
-    } elseif (!empty($u['username'])) {
-        $userName = $u['username'];
-    }
-}
-
-
+$userName = $u['full_name'] ?: ($u['username'] ?? 'User');
 ?>
 <!doctype html>
-<html lang="en">
-
+<html lang="tr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <title>TeklifPro</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TeklifPro</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="assets/app.css">
 </head>
-
 <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <div class="container">
-            <a class="navbar-brand" href="dashboard">TeklifPro</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link" href="customer"><i class="bi bi-people-fill me-1" aria-hidden="true"></i>Müşteriler</a></li>
-                    <li class="nav-item"><a class="nav-link" href="products"><i class="bi bi-box-seam me-1" aria-hidden="true"></i>Ürünler</a></li>
-                    <li class="nav-item"><a class="nav-link" href="quotations"><i class="bi bi-file-earmark-text me-1" aria-hidden="true"></i>Teklifler</a></li>
-                </ul>
-                <ul class="navbar-nav ms-auto">
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            <?php echo htmlspecialchars($userName, ENT_QUOTES, 'UTF-8'); ?>
-                        </a>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
-                            <li><a class="dropdown-item" href="settings">Ayarlar</a></li>
-                            <li><a class="dropdown-item" href="logout">Çıkış Yap</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Page content should follow -->
+<a class="visually-hidden-focusable" href="#content">İçeriğe geç</a>
+<nav class="navbar navbar-expand-lg bg-body-secondary shadow-sm" role="navigation">
+  <div class="container">
+    <a class="navbar-brand" href="dashboard">TeklifPro</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Menüyü Aç">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="customer"><i class="bi bi-people-fill me-1"></i>Müşteriler</a></li>
+        <li class="nav-item"><a class="nav-link" href="products"><i class="bi bi-box-seam me-1"></i>Ürünler</a></li>
+        <li class="nav-item"><a class="nav-link" href="quotations"><i class="bi bi-file-earmark-text me-1"></i>Teklifler</a></li>
+      </ul>
+      <ul class="navbar-nav ms-auto align-items-center">
+        <li class="nav-item">
+          <button id="themeToggle" class="btn btn-link nav-link p-2" title="Tema" aria-label="Tema Değiştir"><i class="bi bi-moon"></i></button>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <?= htmlspecialchars($userName, ENT_QUOTES, 'UTF-8'); ?>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+            <li><a class="dropdown-item" href="settings">Ayarlar</a></li>
+            <li><a class="dropdown-item" href="logout">Çıkış Yap</a></li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<main id="content" class="container py-4">

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/header.php';
+require __DIR__ . '/components/page_header.php';
 
 function e(?string $v): string
 {
@@ -358,32 +359,28 @@ foreach ($slidings as $s) {
 }
 $totalFormatted = number_format($totalAmount, 2, ',', '.') . ' ₺';
 $assemblyLabel = $assemblyTypes[$offer['assembly_type']] ?? 'Bilinmiyor';
-
 ?>
-<div class="container mt-4">
-    <?php if ($success): ?>
-        <div class="alert alert-success"><?= e($success) ?></div>
-    <?php endif; ?>
-    <?php if ($error): ?>
-        <div class="alert alert-danger"><?= e($error) ?></div>
-    <?php endif; ?>
-    <div class="card mb-4">
-        <div class="card-header d-flex justify-content-between align-items-center">
-            <h5 class="mb-0">Teklif #<?= e((string)$offer['id']) ?></h5>
-            <div>
-                <a href="quotations.php" class="btn btn-secondary btn-sm">Geri Dön</a>
-                <a href="quotation_edit.php?id=<?= e((string)$offer['id']) ?>" class="btn btn-primary btn-sm">Düzenle</a>
-                <?php if ($role === 'admin'): ?>
-                    <a href="guillotine_optimize_view.php?id=<?= e((string)$offer['id']) ?>" class="btn btn-success btn-sm">Optimize</a>
-                    <form method="post" class="d-inline" onsubmit="return confirm('Bu teklifi silmek istediğinize emin misiniz?');">
-                        <input type="hidden" name="action" value="delete">
-                        <input type="hidden" name="id" value="<?= e((string)$offer['id']) ?>">
-                        <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
-                        <button type="submit" class="btn btn-danger btn-sm">Sil</button>
-                    </form>
-                <?php endif; ?>
-            </div>
-        </div>
+<nav aria-label="breadcrumb" class="mb-3">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="quotations.php">Teklifler</a></li>
+    <li class="breadcrumb-item active" aria-current="page">#<?= e((string)$offer['id']) ?></li>
+  </ol>
+</nav>
+<?php page_header('Teklif #' . e((string)$offer['id']), '<a href="quotation_edit.php?id=' . e((string)$offer['id']) . '" class="btn btn-primary btn-icon"><i class="bi bi-pencil"></i>Düzenle</a>'); ?>
+<?php if ($success): ?><div class="alert alert-success"><?= e($success) ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert alert-danger"><?= e($error) ?></div><?php endif; ?>
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">Özet</h5>
+        <?php if ($role === 'admin'): ?>
+            <form method="post" class="d-inline">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="id" value="<?= e((string)$offer['id']) ?>">
+                <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
+                <button type="submit" class="btn btn-danger btn-sm" data-confirm="Bu teklifi silmek istediğinize emin misiniz?">Sil</button>
+            </form>
+        <?php endif; ?>
+    </div>
         <div class="card-body">
             <div class="row mb-2">
                 <div class="col-md-6"><strong>Müşteri:</strong> <?= e(trim($offer['first_name'] . ' ' . $offer['last_name'])) ?></div>
@@ -617,7 +614,4 @@ document.getElementById('addGuillotineModal').addEventListener('show.bs.modal', 
     }
 });
 </script>
-
-</body>
-
-</html>
+<?php require __DIR__ . '/footer.php'; ?>

--- a/quotations.php
+++ b/quotations.php
@@ -1,329 +1,121 @@
 <?php
 require __DIR__ . '/header.php';
+require __DIR__ . '/components/page_header.php';
+require __DIR__ . '/components/data_table.php';
 
-function e(?string $v): string
-{
-    return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
+function e(?string $v): string { return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8'); }
+
+$search = trim($_GET['search'] ?? '');
+$status = $_GET['status'] ?? '';
+$deleteId = ($_POST['action'] ?? '') === 'delete' ? (int)($_POST['id'] ?? 0) : 0;
+if ($deleteId) {
+    try {
+        $stmt = $pdo->prepare('DELETE FROM generaloffers WHERE id = :id');
+        $stmt->execute([':id'=>$deleteId]);
+        $_SESSION['flash_success'] = 'Teklif silindi.';
+        header('Location: quotations.php');
+        exit;
+    } catch (Exception $e) { $_SESSION['flash_error'] = 'Teklif silinemedi.'; }
 }
 
-// Montaj tipi etiketleri
-$assemblyTypes = [
-    'demonte' => 'Demonte',
-    'musteri' => 'Müşteri Montajlı',
-    'bayi'    => 'Bayi Montajlı',
-];
-
-$action = $_POST['action'] ?? '';
-$error = null;
-$success = null;
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if ($action === 'create') {
-        $customerId = (int)($_POST['customer_id'] ?? 0);
-        $companyId = (int)($_POST['company_id'] ?? 0);
-        $companyId = $companyId > 0 ? $companyId : null;
-        $offerDate = $_POST['offer_date'] ?? '';
-        $assemblyType = trim($_POST['assembly_type'] ?? '');
-
-        if ($customerId <= 0) {
-            $error = 'Müşteri zorunludur.';
-        } elseif ($offerDate === '') {
-            $error = 'Teklif tarihi zorunludur.';
-        }
-
-        if (!$error) {
-            try {
-                $stmt = $pdo->prepare('INSERT INTO generaloffers (customer_id, company_id, offer_date, assembly_type) VALUES (:customer_id, :company_id, :offer_date, :assembly_type)');
-                $stmt->execute([
-                    ':customer_id' => $customerId,
-                    ':company_id' => $companyId,
-                    ':offer_date' => $offerDate,
-                    ':assembly_type' => $assemblyType ?: null,
-                ]);
-                $success = 'Teklif eklendi.';
-            } catch (Exception $e) {
-                $error = 'Teklif eklenemedi.';
-            }
-        }
-    } elseif ($action === 'edit') {
-        $id = (int)($_POST['id'] ?? 0);
-        $customerId = (int)($_POST['customer_id'] ?? 0);
-        $companyId = (int)($_POST['company_id'] ?? 0);
-        $companyId = $companyId > 0 ? $companyId : null;
-        $offerDate = $_POST['offer_date'] ?? '';
-        $assemblyType = trim($_POST['assembly_type'] ?? '');
-
-        if ($id <= 0) {
-            $error = 'Geçersiz ID.';
-        } elseif ($customerId <= 0) {
-            $error = 'Müşteri zorunludur.';
-        } elseif ($offerDate === '') {
-            $error = 'Teklif tarihi zorunludur.';
-        }
-
-        if (!$error) {
-            try {
-                $stmt = $pdo->prepare('UPDATE generaloffers SET customer_id = :customer_id, company_id = :company_id, offer_date = :offer_date, assembly_type = :assembly_type WHERE id = :id');
-                $stmt->execute([
-                    ':customer_id' => $customerId,
-                    ':company_id' => $companyId,
-                    ':offer_date' => $offerDate,
-                    ':assembly_type' => $assemblyType ?: null,
-                    ':id' => $id,
-                ]);
-                $success = 'Teklif güncellendi.';
-            } catch (Exception $e) {
-                $error = 'Teklif güncellenemedi.';
-            }
-        }
-    } elseif ($action === 'delete') {
-        $id = (int)($_POST['id'] ?? 0);
-        if ($id > 0) {
-            try {
-                $stmt = $pdo->prepare('DELETE FROM generaloffers WHERE id = :id');
-                $stmt->execute([':id' => $id]);
-                $success = 'Teklif silindi.';
-            } catch (Exception $e) {
-                $error = 'Teklif silinemedi.';
-            }
-        } else {
-            $error = 'Geçersiz ID.';
-        }
-    }
-}
-
-// Fetch offers
-try {
-    $stmt = $pdo->prepare('
-        SELECT 
-            g.id,
-            g.customer_id,
-            g.company_id,
-            g.offer_date,
-            g.assembly_type,
-            c.first_name,
-            c.last_name,
-            co.name AS company_name,
-            COALESCE(gs.sum_total, 0) + COALESCE(ss.sum_total, 0) AS total_amount
+$conditions = [];
+$params = [];
+if ($search !== '') { $conditions[] = 'CONCAT(c.first_name, " ", c.last_name) LIKE :term'; $params['term'] = "%$search%"; }
+if ($status !== '') { $conditions[] = 'g.status = :status'; $params['status'] = $status; }
+$sql = 'SELECT g.id, g.offer_date, g.status, CONCAT(c.first_name, " ", c.last_name) AS customer,
+        COALESCE(gs.sum_total,0)+COALESCE(ss.sum_total,0) AS total_amount
         FROM generaloffers g
-        LEFT JOIN customers c ON g.customer_id = c.id
-        LEFT JOIN company co ON g.company_id = co.id
-        LEFT JOIN (
-            SELECT general_offer_id, SUM(total_amount) AS sum_total
-            FROM guillotinesystems
-            GROUP BY general_offer_id
-        ) gs ON gs.general_offer_id = g.id
-        LEFT JOIN (
-            SELECT general_offer_id, SUM(total_amount) AS sum_total
-            FROM slidingsystems
-            GROUP BY general_offer_id
-        ) ss ON ss.general_offer_id = g.id
-        ORDER BY g.offer_date DESC
-    ');
-    $stmt->execute();
-    $offers = $stmt->fetchAll();
-} catch (Exception $e) {
-    $offers = [];
-    $error = $error ?: 'Teklifler alınamadı.';
-}
+        LEFT JOIN customers c ON g.customer_id=c.id
+        LEFT JOIN (SELECT general_offer_id, SUM(total_amount) AS sum_total FROM guillotinesystems GROUP BY general_offer_id) gs ON gs.general_offer_id=g.id
+        LEFT JOIN (SELECT general_offer_id, SUM(total_amount) AS sum_total FROM slidingsystems GROUP BY general_offer_id) ss ON ss.general_offer_id=g.id';
+if ($conditions) { $sql .= ' WHERE '.implode(' AND ', $conditions); }
+$sql .= ' ORDER BY g.offer_date DESC';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$offers = $stmt->fetchAll();
 
-// Fetch customers
-$customers = [];
-try {
-    $cStmt = $pdo->prepare('SELECT id, first_name, last_name, company FROM customers ORDER BY first_name, last_name');
-    $cStmt->execute();
-    $customers = $cStmt->fetchAll();
-} catch (Exception $e) {
-    // ignore
-}
-
-// Fetch companies
-$companies = [];
-try {
-    $coStmt = $pdo->prepare('SELECT id, name FROM company ORDER BY name');
-    $coStmt->execute();
-    $companies = $coStmt->fetchAll();
-} catch (Exception $e) {
-    // ignore
-}
-
+$success = $_SESSION['flash_success'] ?? null; unset($_SESSION['flash_success']);
+$error = $_SESSION['flash_error'] ?? null; unset($_SESSION['flash_error']);
 ?>
-<div class="container py-4">
-    <div class="card shadow-sm">
-        <div class="card-body">
-            <div class="d-flex justify-content-between mb-3">
-                <h4 class="card-title mb-0">Teklifler</h4>
-                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createModal">Yeni Teklif Ekle</button>
-            </div>
-            <?php if ($success): ?>
-                <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    <?= e($success) ?>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            <?php endif; ?>
-            <?php if ($error): ?>
-                <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                    <?= e($error) ?>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            <?php endif; ?>
-            <div class="table-responsive">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>Müşteri</th>
-                            <th>Firma</th>
-                            <th>Teklif Tarihi</th>
-                            <th>Montaj Tipi</th>
-                            <th>Toplam Tutar</th>
-                            <th class="text-end">İşlemler</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if ($offers): ?>
-                            <?php foreach ($offers as $o): ?>
-                                <tr>
-                                    <td><?= e(trim($o['first_name'] . ' ' . $o['last_name'])) ?></td>
-                                    <td><?= e($o['company_name']) ?></td>
-                                    <td><?= e($o['offer_date']) ?></td>
-                                    <td><?= e($assemblyTypes[$o['assembly_type']] ?? $o['assembly_type']) ?></td>
-                                    <td><?= e($o['total_amount']) ?></td>
-                                    <td class="text-end">
-                                        <a href="quotation_view.php?id=<?= (int)$o['id'] ?>" class="btn btn-sm btn-outline-primary me-1">Görüntüle</a>
-                                        <button class="btn btn-sm btn-outline-secondary me-1" data-bs-toggle="modal" data-bs-target="#editModal<?= (int)$o['id'] ?>">Düzenle</button>
-                                        <form method="post" class="d-inline" onsubmit="return confirm('Teklifi silmek istediğinize emin misiniz?');">
-                                            <input type="hidden" name="action" value="delete">
-                                            <input type="hidden" name="id" value="<?= (int)$o['id'] ?>">
-                                            <button type="submit" class="btn btn-sm btn-outline-danger">Sil</button>
-                                        </form>
-                                    </td>
-                                </tr>
-                                <div class="modal fade" id="editModal<?= (int)$o['id'] ?>" tabindex="-1" aria-hidden="true">
-                                    <div class="modal-dialog">
-                                        <div class="modal-content">
-                                            <form method="post">
-                                                <input type="hidden" name="action" value="edit">
-                                                <input type="hidden" name="id" value="<?= (int)$o['id'] ?>">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title">Teklifi Düzenle</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    <div class="mb-3">
-                                                        <label class="form-label">Müşteri</label>
-                                                        <select name="customer_id" class="form-select" required>
-                                                            <option value="">Seçiniz</option>
-                                                            <?php foreach ($customers as $c): ?>
-                                                        <?php
-                                                                    $label = trim($c['first_name'] . ' ' . $c['last_name']);
-                                                                    if (!empty($c['company'])) {
-                                                                        $label .= ' (' . $c['company'] . ')';
-                                                                    }
-                                                                ?>
-                                                                <option value="<?= (int)$c['id'] ?>" <?= $c['id'] == $o['customer_id'] ? 'selected' : '' ?>><?= e($label) ?></option>
-                                                            <?php endforeach; ?>
-                                                        </select>
-                                                    </div>
-                                                    <div class="mb-3">
-                                                        <label class="form-label">Şirket</label>
-                                                        <select name="company_id" class="form-select">
-                                                            <option value="">Seçiniz</option>
-                                                            <?php foreach ($companies as $co): ?>
-                                                                <option value="<?= (int)$co['id'] ?>" <?= $co['id'] == $o['company_id'] ? 'selected' : '' ?>><?= e($co['name']) ?></option>
-                                                            <?php endforeach; ?>
-                                                        </select>
-                                                    </div>
-                                                    <div class="mb-3">
-                                                        <label class="form-label">Teklif Tarihi</label>
-                                                        <input type="date" name="offer_date" class="form-control" required value="<?= e($o['offer_date']) ?>">
-                                                    </div>
-                                                    <div class="mb-3">
-                                                        <label class="form-label">Montaj Tipi</label>
-                                                        <select name="assembly_type" class="form-select">
-                                                            <option value="">Seçiniz</option>
-                                                            <?php foreach ($assemblyTypes as $code => $label): ?>
-                                                                <option value="<?= e($code) ?>" <?= $code === $o['assembly_type'] ? 'selected' : '' ?>><?= e($label) ?></option>
-                                                            <?php endforeach; ?>
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Vazgeç</button>
-                                                    <button type="submit" class="btn btn-primary">Kaydet</button>
-                                                </div>
-                                            </form>
-                                        </div>
-                                    </div>
-                                </div>
-                            <?php endforeach; ?>
-                        <?php else: ?>
-                            <tr>
-                                <td colspan="6" class="text-center text-muted">Teklif bulunamadı.</td>
-                            </tr>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-</div>
+<?php page_header('Teklifler', '<a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createModal"><i class="bi bi-plus"></i> Yeni Teklif</a>'); ?>
+<form class="row g-2 mb-3" method="get">
+  <div class="col-md-6">
+    <input type="search" name="search" class="form-control" placeholder="Ara" value="<?= e($search) ?>">
+  </div>
+  <div class="col-md-6 d-flex align-items-center gap-2">
+    <?php foreach ([""=>'Tümü','active'=>'Aktif','pending'=>'Beklemede','closed'=>'Kapalı'] as $code=>$label): ?>
+      <a href="quotations?<?= http_build_query(['status'=>$code===''?null:$code, 'search'=>$search]) ?>" class="badge rounded-pill <?= $status===$code?'text-bg-primary':'text-bg-light' ?>"><?= $label ?></a>
+    <?php endforeach; ?>
+  </div>
+</form>
+<?php if ($success): ?><div class="alert alert-success" role="alert"><?= e($success) ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert alert-danger" role="alert"><?= e($error) ?></div><?php endif; ?>
+<?php data_table_start(['#','Müşteri','Tarih','Tutar','Durum','İşlemler']); ?>
+<?php if ($offers): foreach ($offers as $o): ?>
+<tr>
+  <td><?= (int)$o['id'] ?></td>
+  <td><?= e($o['customer']) ?></td>
+  <td><time datetime="<?= e($o['offer_date']) ?>"><?= e($o['offer_date']) ?></time></td>
+  <td><?= number_format((float)$o['total_amount'],2,',','.') ?> ₺</td>
+  <td><?= e($o['status']) ?></td>
+  <td class="text-end">
+    <a href="quotation_view.php?id=<?= (int)$o['id'] ?>" class="btn btn-sm btn-outline-secondary" title="Görüntüle"><i class="bi bi-eye"></i></a>
+    <a href="quotation_view.php?id=<?= (int)$o['id'] ?>&edit=1" class="btn btn-sm btn-outline-secondary" title="Düzenle"><i class="bi bi-pencil"></i></a>
+    <form method="post" class="d-inline">
+      <input type="hidden" name="action" value="delete">
+      <input type="hidden" name="id" value="<?= (int)$o['id'] ?>">
+      <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="Bu teklif silinsin mi?" title="Sil"><i class="bi bi-trash"></i></button>
+    </form>
+  </td>
+</tr>
+<?php endforeach; else: ?>
+<tr><td colspan="6" class="text-center text-muted">Teklif bulunamadı.</td></tr>
+<?php endif; ?>
+<?php data_table_end(); ?>
 
+<?php
+// Fetch customers and companies for create modal
+$customers = $pdo->query('SELECT id, first_name, last_name, company_name AS company FROM customers ORDER BY first_name')->fetchAll();
+$companies = $pdo->query('SELECT id, name FROM company ORDER BY name')->fetchAll();
+?>
 <div class="modal fade" id="createModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <form method="post">
-                <input type="hidden" name="action" value="create">
-                <div class="modal-header">
-                    <h5 class="modal-title">Yeni Teklif</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label">Müşteri</label>
-                        <select name="customer_id" class="form-select" required>
-                            <option value="">Seçiniz</option>
-                            <?php foreach ($customers as $c): ?>
-                        <?php
-                            $label = trim($c['first_name'] . ' ' . $c['last_name']);
-                            if (!empty($c['company'])) {
-                                $label .= ' (' . $c['company'] . ')';
-                            }
-                        ?>
-                        <option value="<?= (int)$c['id'] ?>"><?= e($label) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="mb-3">
-                <label class="form-label">Şirket</label>
-                <select name="company_id" class="form-select">
-                    <option value="">Seçiniz</option>
-                    <?php foreach ($companies as $co): ?>
-                        <option value="<?= (int)$co['id'] ?>"><?= e($co['name']) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="mb-3">
-                <label class="form-label">Teklif Tarihi</label>
-                <input type="date" name="offer_date" class="form-control" required>
-            </div>
-            <div class="mb-3">
-                <label class="form-label">Montaj Tipi</label>
-                <select name="assembly_type" class="form-select">
-                    <option value="">Seçiniz</option>
-                    <?php foreach ($assemblyTypes as $code => $label): ?>
-                        <option value="<?= e($code) ?>"><?= e($label) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="quotation_view.php">
+        <div class="modal-header">
+          <h5 class="modal-title">Yeni Teklif</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Müşteri</label>
+            <select name="customer_id" class="form-select" required>
+              <option value="">Seçiniz</option>
+              <?php foreach ($customers as $c): $label = trim($c['first_name'].' '.$c['last_name']); if (!empty($c['company'])) $label.=' ('.$c['company'].')'; ?>
+              <option value="<?= (int)$c['id'] ?>"><?= e($label) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Şirket</label>
+            <select name="company_id" class="form-select">
+              <option value="">Seçiniz</option>
+              <?php foreach ($companies as $co): ?>
+              <option value="<?= (int)$co['id'] ?>"><?= e($co['name']) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Teklif Tarihi</label>
+            <input type="date" name="offer_date" class="form-control" required>
+          </div>
         </div>
         <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Vazgeç</button>
-            <button type="submit" class="btn btn-primary">Kaydet</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+          <button type="submit" class="btn btn-primary">Kaydet</button>
         </div>
-            </form>
-        </div>
+      </form>
     </div>
+  </div>
 </div>
-
-</body>
-</html>
+<?php require __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add design tokens, dark mode, and utilities in app.css
- implement JS helpers for theme toggle, toasts, confirm modal, and form submit state
- introduce reusable components and refactor dashboard and customer views

## Testing
- `php -l header.php footer.php dashboard.php customer.php quotations.php quotation_view.php customers/add.php customers/edit.php components/page_header.php components/stat_card.php components/data_table.php components/form_group.php`


------
https://chatgpt.com/codex/tasks/task_e_689b45727ef883289a8dde9e32ee60a9