### PR TITLE
Handle missing composer autoload file

### DIFF
--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -8,7 +8,13 @@ if (empty($_SESSION['user_id'])) {
 }
 
 require __DIR__ . '/../config.php';
-require __DIR__ . '/../vendor/autoload.php';
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($autoload)) {
+    http_response_code(500);
+    exit('Composer autoload file not found. Run "composer install".');
+}
+require $autoload;
 
 function e(?string $v): string { return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8'); }
 function money_tr(float $v): string { return number_format($v, 2, ',', '.') . ' ₺'; }


### PR DESCRIPTION
## Summary
- ensure `render_quotation_pdf.php` fails gracefully when Composer dependencies are missing

## Testing
- `php -l pdf/render_quotation_pdf.php`


------
https://chatgpt.com/codex/tasks/task_e_689c4932710483289797b2bf29f483c8