### PR TITLE
Remove edit button from quotations page

### DIFF
--- a/quotations.php
+++ b/quotations.php
@@ -174,7 +174,6 @@ $error   = $_SESSION['flash_error'] ?? null; unset($_SESSION['flash_error']);
   <td><?= e($o['status']) ?></td>
   <td class="text-end">
     <a href="quotation_view.php?id=<?= (int)$o['id'] ?>" class="btn btn-sm btn-outline-secondary" title="Görüntüle"><i class="bi bi-eye"></i></a>
-    <a href="quotation_view.php?id=<?= (int)$o['id'] ?>&edit=1" class="btn btn-sm btn-outline-secondary" title="Düzenle"><i class="bi bi-pencil"></i></a>
     <form method="post" class="d-inline">
       <input type="hidden" name="action" value="delete">
       <input type="hidden" name="id" value="<?= (int)$o['id'] ?>">


### PR DESCRIPTION
## Summary
- Remove the 'Düzenle' (edit) button from the quotations list

## Testing
- `php -l quotations.php`


------
https://chatgpt.com/codex/tasks/task_e_689c6e264e7483288d15a865638de7fd