### PR TITLE
Center table headers on customer and quotations pages

### DIFF
--- a/components/data_table.php
+++ b/components/data_table.php
@@ -1,10 +1,10 @@
 <?php
-function data_table_start(array $headers): void {
+function data_table_start(array $headers, string $headerClass = ''): void {
 ?>
 <div class="table-responsive">
 <table class="table table-hover align-middle">
   <thead class="table-light sticky-top">
-    <tr>
+    <tr<?= $headerClass ? ' class="' . htmlspecialchars($headerClass, ENT_QUOTES, 'UTF-8') . '"' : '' ?>>
       <?php foreach ($headers as $h): ?>
         <th scope="col"><?= htmlspecialchars($h, ENT_QUOTES, 'UTF-8'); ?></th>
       <?php endforeach; ?>

--- a/customer.php
+++ b/customer.php
@@ -60,7 +60,7 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
     <button class="btn btn-outline-secondary" type="submit"><i class="bi bi-search"></i></button>
   </div>
 </form>
-<?php data_table_start(['İsim','Şirket','Email','Telefon','Kayıt Tarihi','İşlemler']); ?>
+<?php data_table_start(['İsim','Şirket','Email','Telefon','Kayıt Tarihi','İşlemler'], 'text-center'); ?>
 <?php if ($customers): foreach ($customers as $cust): ?>
 <tr class="text-center">
   <td><?= htmlspecialchars(trim(($cust['first_name'] ?? '') . ' ' . ($cust['last_name'] ?? '')), ENT_QUOTES, 'UTF-8'); ?></td>

--- a/quotations.php
+++ b/quotations.php
@@ -160,7 +160,7 @@ $error   = $_SESSION['flash_error'] ?? null; unset($_SESSION['flash_error']);
 </form>
 <?php if ($success): ?><div class="alert alert-success" role="alert"><?= e($success) ?></div><?php endif; ?>
 <?php if ($error): ?><div class="alert alert-danger" role="alert"><?= e($error) ?></div><?php endif; ?>
-<?php data_table_start(['#','Müşteri','Montaj','Ödeme','Süre','Vade','Tarih','Tutar','Durum','İşlemler']); ?>
+<?php data_table_start(['#','Müşteri','Montaj','Ödeme','Süre','Vade','Tarih','Tutar','Durum','İşlemler'], 'text-center'); ?>
 <?php if ($offers): foreach ($offers as $o): ?>
 <tr class="text-center">
   <td><?= (int)$o['id'] ?></td>


### PR DESCRIPTION
## Summary
- Allow passing an optional CSS class to table header rows.
- Center table headers on the customers and quotations pages using the new option.

## Testing
- `php -l components/data_table.php`
- `php -l customer.php`
- `php -l quotations.php`


------
https://chatgpt.com/codex/tasks/task_e_689c6fdb51d88328a0ce102480ec9455