### PR TITLE
Remove hardcoded base path

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,11 +5,9 @@ if (!defined('BOOTSTRAP_LOADED')) {
     ini_set('display_errors', '0');
     ini_set('log_errors', '1');
 
-    define('BASE_PATH', '/teklifpro');
-
     function url(string $path = ''): string
     {
-        return BASE_PATH . '/' . ltrim($path, '/');
+        return '/' . ltrim($path, '/');
     }
 
     set_error_handler(function ($severity, $message, $file, $line) {

--- a/index.php
+++ b/index.php
@@ -6,10 +6,6 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$base = rtrim(BASE_PATH, '/') . '/';
-if (strpos($uri, $base) === 0) {
-    $uri = substr($uri, strlen($base));
-}
 $uri = trim($uri, '/');
 
 if ($uri === '' || $uri === 'index.php') {


### PR DESCRIPTION
## Summary
- remove BASE_PATH definition and simplify url helper
- trim request URIs directly without base path

## Testing
- `php -l bootstrap.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_689c7314f8c483288936bf3cf7c8c079