### PR TITLE
Use Bootstrap in error pages

### DIFF
--- a/errors/403.php
+++ b/errors/403.php
@@ -3,17 +3,20 @@ http_response_code(403);
 require __DIR__ . '/../bootstrap.php';
 ?>
 <!doctype html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>403 Forbidden</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="<?= url('assets/app.css') ?>">
 </head>
-<body>
+<body class="bg-light">
 <div class="container py-5 text-center">
-    <h1>403 - Forbidden</h1>
-    <p>You do not have permission to access this page.</p>
-    <a href="<?= url('') ?>">Return home</a>
+    <h1 class="display-4">403 - Forbidden</h1>
+    <p class="lead">You do not have permission to access this page.</p>
+    <a href="<?= url('') ?>" class="btn btn-primary mt-3">Return home</a>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/errors/404.php
+++ b/errors/404.php
@@ -3,17 +3,20 @@ http_response_code(404);
 require __DIR__ . '/../bootstrap.php';
 ?>
 <!doctype html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>404 Not Found</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="<?= url('assets/app.css') ?>">
 </head>
-<body>
+<body class="bg-light">
 <div class="container py-5 text-center">
-    <h1>404 - Page Not Found</h1>
-    <p>The page you requested could not be found.</p>
-    <a href="<?= url('') ?>">Return home</a>
+    <h1 class="display-4">404 - Page Not Found</h1>
+    <p class="lead">The page you requested could not be found.</p>
+    <a href="<?= url('') ?>" class="btn btn-primary mt-3">Return home</a>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/errors/500.php
+++ b/errors/500.php
@@ -3,17 +3,20 @@ http_response_code(500);
 require __DIR__ . '/../bootstrap.php';
 ?>
 <!doctype html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>500 Internal Server Error</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="<?= url('assets/app.css') ?>">
 </head>
-<body>
+<body class="bg-light">
 <div class="container py-5 text-center">
-    <h1>500 - Internal Server Error</h1>
-    <p>Something went wrong. Please try again later.</p>
-    <a href="<?= url('') ?>">Return home</a>
+    <h1 class="display-4">500 - Internal Server Error</h1>
+    <p class="lead">Something went wrong. Please try again later.</p>
+    <a href="<?= url('') ?>" class="btn btn-primary mt-3">Return home</a>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Bootstrap CDN links and responsive meta tags to 403, 404 and 500 error pages
- restyle error page content with Bootstrap utilities and buttons

## Testing
- `php -l errors/403.php errors/404.php errors/500.php`


------
https://chatgpt.com/codex/tasks/task_e_689c788a90c48328a4e1c51b67c91aca