### PR TITLE
Add installment payment support to quotations

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -57,3 +57,7 @@ body.dark .skeleton { background: #495057; }
   clip:auto;
   white-space:normal;
 }
+
+input[type=number] {
+  text-align: right;
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,6 +10,11 @@ if (!defined('BOOTSTRAP_LOADED')) {
         return '/' . ltrim($path, '/');
     }
 
+    function tr_money(float $v): string
+    {
+        return number_format($v, 2, ',', '.');
+    }
+
     set_error_handler(function ($severity, $message, $file, $line) {
         if (!(error_reporting() & $severity)) {
             return false;

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -398,8 +398,103 @@ foreach ($guillotines as $g) {
 foreach ($slidings as $s) {
     $totalAmount += (float)$s['total_amount'];
 }
-$totalFormatted = number_format($totalAmount, 2, ',', '.') . ' ₺';
+$subtotalCalc = round($totalAmount / 1.2, 2);
+$vatAmountCalc = round($totalAmount - $subtotalCalc, 2);
+$totalFormatted = tr_money($totalAmount) . ' ₺';
 $assemblyLabel = $assemblyTypes[$offer['assembly_type']] ?? 'Bilinmiyor';
+
+$paymentErrors = [];
+$paymentData = [
+    'payment_type' => $offer['payment_type'] ?? 'cash',
+    'term_months' => $offer['term_months'] !== null ? (string)$offer['term_months'] : '',
+    'interest_mode' => $offer['interest_mode'] ?? 'percent',
+    'interest_value' => $offer['interest_value'] !== null ? (string)$offer['interest_value'] : '',
+    'grace_days' => (string)($offer['grace_days'] ?? 0),
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'update_payment') {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!hash_equals($csrfToken, $token)) {
+        $paymentErrors['form'] = 'Geçersiz CSRF tokenı.';
+    }
+    $paymentType = $_POST['payment_type'] === 'installment' ? 'installment' : 'cash';
+    $termMonths = null;
+    $interestMode = null;
+    $interestValue = null;
+    $graceDays = 0;
+    $interestAmount = null;
+    $totalWithInterest = round($subtotalCalc + $vatAmountCalc, 2);
+    $monthlyInstallment = null;
+    if ($paymentType === 'installment') {
+        $termMonths = filter_input(INPUT_POST, 'term_months', FILTER_VALIDATE_INT);
+        if ($termMonths === false || $termMonths < 1 || $termMonths > 60) {
+            $paymentErrors['term_months'] = '1-60 arası ay giriniz.';
+        }
+        $interestMode = $_POST['interest_mode'] === 'fixed' ? 'fixed' : 'percent';
+        if ($interestMode === 'percent') {
+            $interestValue = filter_var($_POST['interest_value_percent'], FILTER_VALIDATE_FLOAT);
+            if ($interestValue === false || $interestValue < 0 || $interestValue > 100) {
+                $paymentErrors['interest_value'] = '0-100 arası yüzde giriniz.';
+            }
+        } else {
+            $interestValue = filter_var($_POST['interest_value_fixed'], FILTER_VALIDATE_FLOAT);
+            if ($interestValue === false || $interestValue < 0) {
+                $paymentErrors['interest_value'] = '0 veya üzeri tutar giriniz.';
+            }
+        }
+        $graceDays = filter_input(INPUT_POST, 'grace_days', FILTER_VALIDATE_INT);
+        if ($graceDays === false || $graceDays < 0 || $graceDays > 180) {
+            $paymentErrors['grace_days'] = '0-180 arası gün giriniz.';
+            $graceDays = 0;
+        }
+        if (!$paymentErrors) {
+            if ($interestMode === 'percent') {
+                $interestAmount = round(($subtotalCalc + $vatAmountCalc) * ($interestValue / 100), 2);
+            } else {
+                $interestAmount = round($interestValue, 2);
+            }
+            $totalWithInterest = round($subtotalCalc + $vatAmountCalc + $interestAmount, 2);
+            $monthlyInstallment = round($totalWithInterest / $termMonths, 2);
+        }
+    }
+    if (!$paymentErrors) {
+        try {
+            $upd = $pdo->prepare('UPDATE generaloffers SET payment_type=:payment_type, term_months=:term_months, interest_mode=:interest_mode, interest_value=:interest_value, interest_amount=:interest_amount, total_with_interest=:total_with_interest, monthly_installment=:monthly_installment, grace_days=:grace_days WHERE id=:id');
+            $upd->bindValue(':payment_type', $paymentType);
+            $upd->bindValue(':term_months', $termMonths, $termMonths === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+            $upd->bindValue(':interest_mode', $interestMode, $interestMode === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $upd->bindValue(':interest_value', $interestValue, $interestValue === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $upd->bindValue(':interest_amount', $interestAmount, $interestAmount === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $upd->bindValue(':total_with_interest', $totalWithInterest, PDO::PARAM_STR);
+            $upd->bindValue(':monthly_installment', $monthlyInstallment, $monthlyInstallment === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $upd->bindValue(':grace_days', $graceDays, PDO::PARAM_INT);
+            $upd->bindValue(':id', $id, PDO::PARAM_INT);
+            $upd->execute();
+            $success = 'Ödeme şartları güncellendi.';
+            $offer = array_merge($offer, [
+                'payment_type' => $paymentType,
+                'term_months' => $termMonths,
+                'interest_mode' => $interestMode,
+                'interest_value' => $interestValue,
+                'interest_amount' => $interestAmount,
+                'total_with_interest' => $totalWithInterest,
+                'monthly_installment' => $monthlyInstallment,
+                'grace_days' => $graceDays,
+            ]);
+            $paymentData = [
+                'payment_type' => $paymentType,
+                'term_months' => $termMonths !== null ? (string)$termMonths : '',
+                'interest_mode' => $interestMode,
+                'interest_value' => $interestValue !== null ? (string)$interestValue : '',
+                'grace_days' => (string)$graceDays,
+            ];
+        } catch (Exception $e) {
+            $paymentErrors['form'] = 'Ödeme şartları kaydedilemedi.';
+        }
+    } else {
+        http_response_code(422);
+    }
+}
 ?>
 <nav aria-label="breadcrumb" class="mb-3">
   <ol class="breadcrumb">
@@ -469,6 +564,77 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
             <div class="row">
                 <div class="col-md-6"><strong>Toplam Tutar:</strong> <?= e($totalFormatted) ?></div>
             </div>
+        </div>
+    </div>
+
+    <div class="card mb-4" id="payment-terms" data-subtotal="<?= e((string)$subtotalCalc) ?>" data-vat="<?= e((string)$vatAmountCalc) ?>">
+        <div class="card-header">
+            <h5 class="mb-0">Ödeme Şartları</h5>
+        </div>
+        <div class="card-body">
+            <?php if (!empty($paymentErrors['form'])): ?><div class="alert alert-danger"><?= e($paymentErrors['form']) ?></div><?php endif; ?>
+            <form method="post">
+                <input type="hidden" name="action" value="update_payment">
+                <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
+                <div class="mb-3">
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="payment_type" id="payment_type_cash" value="cash" <?= $paymentData['payment_type'] === 'cash' ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="payment_type_cash">Peşin</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="payment_type" id="payment_type_installment" value="installment" <?= $paymentData['payment_type'] === 'installment' ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="payment_type_installment">Vadeli</label>
+                    </div>
+                </div>
+                <div id="installment_section" <?= $paymentData['payment_type'] === 'installment' ? '' : 'style="display:none;"' ?>>
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label class="form-label">Vade (Ay)</label>
+                            <input type="number" name="term_months" id="term_months" min="1" max="60" class="form-control <?= isset($paymentErrors['term_months']) ? 'is-invalid' : '' ?>" value="<?= e($paymentData['term_months']) ?>">
+                            <?php if(isset($paymentErrors['term_months'])): ?><div class="invalid-feedback"><?= e($paymentErrors['term_months']) ?></div><?php endif; ?>
+                        </div>
+                        <div class="col-md-8">
+                            <label class="form-label d-block">Vade Farkı Türü</label>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" name="interest_mode" id="interest_mode_percent" value="percent" <?= $paymentData['interest_mode'] === 'percent' ? 'checked' : '' ?>>
+                                <label class="form-check-label" for="interest_mode_percent">Yüzde (%)</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" name="interest_mode" id="interest_mode_fixed" value="fixed" <?= $paymentData['interest_mode'] === 'fixed' ? 'checked' : '' ?>>
+                                <label class="form-check-label" for="interest_mode_fixed">Tutar (TRY)</label>
+                            </div>
+                            <div class="mt-2" id="interest_percent_field" <?= $paymentData['interest_mode'] === 'percent' ? '' : 'style="display:none;"' ?>>
+                                <input type="number" step="0.01" min="0" max="100" name="interest_value_percent" id="interest_value_percent" class="form-control <?= isset($paymentErrors['interest_value']) ? 'is-invalid' : '' ?>" value="<?= $paymentData['interest_mode'] === 'percent' ? e($paymentData['interest_value']) : '' ?>">
+                                <?php if(isset($paymentErrors['interest_value']) && $paymentData['interest_mode'] === 'percent'): ?><div class="invalid-feedback"><?= e($paymentErrors['interest_value']) ?></div><?php endif; ?>
+                            </div>
+                            <div class="mt-2" id="interest_fixed_field" <?= $paymentData['interest_mode'] === 'fixed' ? '' : 'style="display:none;"' ?>>
+                                <input type="number" step="0.01" min="0" name="interest_value_fixed" id="interest_value_fixed" class="form-control <?= isset($paymentErrors['interest_value']) ? 'is-invalid' : '' ?>" value="<?= $paymentData['interest_mode'] === 'fixed' ? e($paymentData['interest_value']) : '' ?>">
+                                <?php if(isset($paymentErrors['interest_value']) && $paymentData['interest_mode'] === 'fixed'): ?><div class="invalid-feedback"><?= e($paymentErrors['interest_value']) ?></div><?php endif; ?>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Erteleme (Gün)</label>
+                            <input type="number" name="grace_days" id="grace_days" min="0" max="180" class="form-control <?= isset($paymentErrors['grace_days']) ? 'is-invalid' : '' ?>" value="<?= e($paymentData['grace_days']) ?>">
+                            <?php if(isset($paymentErrors['grace_days'])): ?><div class="invalid-feedback"><?= e($paymentErrors['grace_days']) ?></div><?php endif; ?>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Vade Farkı Tutarı (TRY)</label>
+                            <input type="text" id="interest_amount_preview" class="form-control" readonly value="<?= $offer['interest_amount'] !== null ? e(tr_money((float)$offer['interest_amount'])) : '' ?>">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Toplam (Vade Dahil) (TRY)</label>
+                            <input type="text" id="total_with_interest_preview" class="form-control" readonly value="<?= $offer['total_with_interest'] !== null ? e(tr_money((float)$offer['total_with_interest'])) : '' ?>">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Aylık Taksit (TRY)</label>
+                            <input type="text" id="monthly_installment_preview" class="form-control" readonly value="<?= $offer['monthly_installment'] !== null ? e(tr_money((float)$offer['monthly_installment'])) : '' ?>">
+                        </div>
+                    </div>
+                </div>
+                <div class="text-end mt-3">
+                    <button type="submit" class="btn btn-primary">Kaydet</button>
+                </div>
+            </form>
         </div>
     </div>
 
@@ -678,5 +844,57 @@ document.getElementById('addGuillotineModal').addEventListener('show.bs.modal', 
         this.querySelector('.modal-title').textContent = 'Add Guillotine System Offer';
     }
 });
+
+const payCard = document.getElementById('payment-terms');
+if (payCard) {
+    const subtotal = parseFloat(payCard.dataset.subtotal || '0');
+    const vat = parseFloat(payCard.dataset.vat || '0');
+    const installmentSection = document.getElementById('installment_section');
+    const interestPercentField = document.getElementById('interest_percent_field');
+    const interestFixedField = document.getElementById('interest_fixed_field');
+    const interestAmountPreview = document.getElementById('interest_amount_preview');
+    const totalWithInterestPreview = document.getElementById('total_with_interest_preview');
+    const monthlyInstallmentPreview = document.getElementById('monthly_installment_preview');
+
+    function recalc() {
+        const paymentType = document.querySelector('input[name="payment_type"]:checked').value;
+        if (paymentType !== 'installment') {
+            installmentSection.style.display = 'none';
+            interestAmountPreview.value = '';
+            totalWithInterestPreview.value = '';
+            monthlyInstallmentPreview.value = '';
+            return;
+        }
+        installmentSection.style.display = '';
+        const term = parseInt(document.getElementById('term_months').value, 10) || 0;
+        const mode = document.querySelector('input[name="interest_mode"]:checked').value;
+        let interestValue = 0;
+        let interestAmount = 0;
+        if (mode === 'percent') {
+            interestPercentField.style.display = '';
+            interestFixedField.style.display = 'none';
+            interestValue = parseFloat(document.getElementById('interest_value_percent').value) || 0;
+            interestAmount = (subtotal + vat) * (interestValue / 100);
+        } else {
+            interestPercentField.style.display = 'none';
+            interestFixedField.style.display = '';
+            interestValue = parseFloat(document.getElementById('interest_value_fixed').value) || 0;
+            interestAmount = interestValue;
+        }
+        const totalWithInterest = subtotal + vat + interestAmount;
+        const monthly = term ? totalWithInterest / term : 0;
+        interestAmountPreview.value = interestAmount.toFixed(2).replace('.', ',');
+        totalWithInterestPreview.value = totalWithInterest.toFixed(2).replace('.', ',');
+        monthlyInstallmentPreview.value = monthly.toFixed(2).replace('.', ',');
+    }
+
+    document.querySelectorAll('input[name="payment_type"]').forEach(el => el.addEventListener('change', recalc));
+    document.querySelectorAll('input[name="interest_mode"]').forEach(el => el.addEventListener('change', recalc));
+    ['term_months','interest_value_percent','interest_value_fixed'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) { el.addEventListener('input', recalc); }
+    });
+    recalc();
+}
 </script>
 <?php require __DIR__ . '/footer.php'; ?>

--- a/quotations.php
+++ b/quotations.php
@@ -40,6 +40,14 @@ try {
     $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS payment_method VARCHAR(100) NULL AFTER assembly_type");
     $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS validity_days INT NULL AFTER payment_method");
     $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS installment_term VARCHAR(100) NULL AFTER validity_days");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS payment_type ENUM('cash','installment') NOT NULL DEFAULT 'cash' AFTER installment_term");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS term_months INT NULL AFTER payment_type");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS interest_mode ENUM('percent','fixed') NULL AFTER term_months");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS interest_value DECIMAL(12,2) NULL AFTER interest_mode");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS interest_amount DECIMAL(12,2) NULL AFTER interest_value");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS total_with_interest DECIMAL(12,2) NULL AFTER interest_amount");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS monthly_installment DECIMAL(12,2) NULL AFTER total_with_interest");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS grace_days INT NULL DEFAULT 0 AFTER monthly_installment");
 } catch (Exception $e) {
     // ignore migration errors
 }


### PR DESCRIPTION
## Summary
- add `tr_money()` helper and numeric-field styling for consistent currency formatting
- extend generaloffers table for installment payment columns
- implement installment payment form, validation, and calculation logic with live previews

## Testing
- `php -l bootstrap.php`
- `php -l quotations.php`
- `php -l quotation_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689c8a37f2308328b32cecee7465d2c3