### PR TITLE
Left-align number inputs on quotations page

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -58,6 +58,7 @@ body.dark .skeleton { background: #495057; }
   white-space:normal;
 }
 
-input[type=number] {
-  text-align: right;
+input[type=number],
+.form-control[type=number] {
+  text-align: left !important;
 }


### PR DESCRIPTION
## Summary
- Override default number input alignment so all numeric fields are left-aligned

## Testing
- `php -l quotations.php`

------
https://chatgpt.com/codex/tasks/task_e_689c9317c7248328b0f247e5459dcb9a