### PR TITLE
Align quotation edit form with creation modal

### DIFF
--- a/quotation_edit.php
+++ b/quotation_edit.php
@@ -1,7 +1,6 @@
 <?php
 require __DIR__ . '/header.php';
 require __DIR__ . '/components/page_header.php';
-require __DIR__ . '/components/form_group.php';
 
 function e(?string $v): string { return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8'); }
 
@@ -16,6 +15,7 @@ $paymentLabels = [
     'bank_transfer' => 'Havale/EFT',
     'credit_card'   => 'Kredi Kartı',
     'installment'   => 'Taksitli',
+    'vadeli'        => 'Vadeli',
     'other'         => 'Diğer',
 ];
 
@@ -45,6 +45,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $paymentMethod   = $_POST['payment_method'] ?? '';
     $validityDays    = trim($_POST['validity_days'] ?? '');
     $installmentTerm = trim($_POST['installment_term'] ?? '');
+    $termMonths      = trim($_POST['term_months'] ?? '');
+    $interestValue   = trim($_POST['interest_value'] ?? '');
 
     if ($customerId <= 0) { $errors['customer_id'] = 'Müşteri zorunludur.'; }
     if ($offerDate === '' || !strtotime($offerDate)) { $errors['offer_date'] = 'Geçerli tarih girin.'; }
@@ -59,19 +61,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $validityInt = (int)$validityDays;
         }
     }
-    if ($installmentTerm !== '' && mb_strlen($installmentTerm) > 100) {
-        $errors['installment_term'] = 'Vade en fazla 100 karakter olabilir.';
+    if ($paymentMethod === 'vadeli') {
+        if ($termMonths === '' || !ctype_digit($termMonths) || (int)$termMonths < 1) {
+            $errors['term_months'] = 'Vade süresi geçerli bir sayı olmalıdır.';
+        }
+        if ($interestValue === '' || !is_numeric($interestValue)) {
+            $errors['interest_value'] = 'Vade farkı geçerli bir sayı olmalıdır.';
+        }
+        $installmentTerm = '';
+    } else {
+        if ($installmentTerm !== '' && mb_strlen($installmentTerm) > 100) {
+            $errors['installment_term'] = 'Vade en fazla 100 karakter olabilir.';
+        }
+        $termMonths = '';
+        $interestValue = '';
     }
 
     if (!$errors) {
         try {
-            $stmt = $pdo->prepare('UPDATE generaloffers SET customer_id=:customer_id, offer_date=:offer_date, assembly_type=:assembly_type, payment_method=:payment_method, validity_days=:validity_days, installment_term=:installment_term WHERE id=:id');
+            $stmt = $pdo->prepare('UPDATE generaloffers SET customer_id=:customer_id, offer_date=:offer_date, assembly_type=:assembly_type, payment_method=:payment_method, validity_days=:validity_days, installment_term=:installment_term, term_months=:term_months, interest_value=:interest_value WHERE id=:id');
             $stmt->bindValue(':customer_id', $customerId, PDO::PARAM_INT);
             $stmt->bindValue(':offer_date', $offerDate);
             $stmt->bindValue(':assembly_type', $assemblyType);
             $stmt->bindValue(':payment_method', $paymentMethod);
             $stmt->bindValue(':validity_days', $validityInt, $validityInt === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
             $stmt->bindValue(':installment_term', $installmentTerm !== '' ? $installmentTerm : null, $installmentTerm === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $stmt->bindValue(':term_months', $termMonths !== '' ? (int)$termMonths : null, $termMonths === '' ? PDO::PARAM_NULL : PDO::PARAM_INT);
+            $stmt->bindValue(':interest_value', $interestValue !== '' ? $interestValue : null, $interestValue === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
             $stmt->bindValue(':id', $id, PDO::PARAM_INT);
             $stmt->execute();
             $success = 'Teklif güncellendi.';
@@ -82,6 +98,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'payment_method'   => $paymentMethod,
                 'validity_days'    => $validityInt,
                 'installment_term' => $installmentTerm,
+                'term_months'      => $termMonths !== '' ? (int)$termMonths : null,
+                'interest_value'   => $interestValue !== '' ? $interestValue : null,
             ]);
         } catch (Exception $e) {
             $errors['form'] = 'Güncellenemedi.';
@@ -94,39 +112,77 @@ page_header('Teklifi Düzenle');
 <?php if ($success): ?><div class="alert alert-success" role="alert"><?= e($success) ?></div><?php endif; ?>
 <?php if ($errors): ?><div class="alert alert-danger" role="alert">Lütfen formu kontrol edin.</div><?php endif; ?>
 <form method="post" novalidate>
-<?php
-$customerOptions = '<option value="">Seçiniz</option>';
-foreach ($customers as $c) {
-    $label = trim(($c['first_name'] ?? '') . ' ' . ($c['last_name'] ?? ''));
-    if (!empty($c['company'])) { $label .= ' (' . $c['company'] . ')'; }
-    $selected = ((int)$offer['customer_id'] === (int)$c['id']) ? ' selected' : '';
-    $customerOptions .= '<option value="' . (int)$c['id'] . '"' . $selected . '>' . e($label) . '</option>';
-}
-form_group('customer_id', 'Müşteri', "<select name='customer_id' id='customer_id' class='form-select' required>$customerOptions</select>", '', $errors['customer_id'] ?? '');
-
-$assemblyOptions = '<option value="">Seçiniz</option>';
-foreach ($assemblyTypes as $key => $label) {
-    $selected = ($offer['assembly_type'] === $key) ? ' selected' : '';
-    $assemblyOptions .= '<option value="' . e($key) . '"' . $selected . '>' . e($label) . '</option>';
-}
-form_group('assembly_type', 'Montaj Tipi', "<select name='assembly_type' id='assembly_type' class='form-select' required>$assemblyOptions</select>", '', $errors['assembly_type'] ?? '');
-
- form_group('offer_date', 'Teklif Tarihi', "<input type='date' class='form-control' id='offer_date' name='offer_date' required value='" . e($offer['offer_date']) . "'>", '', $errors['offer_date'] ?? '');
-
- $paymentOptions = '<option value="">Seçiniz</option>';
- foreach ($paymentLabels as $key => $label) {
-     $selected = ($offer['payment_method'] === $key) ? ' selected' : '';
-     $paymentOptions .= '<option value="' . e($key) . '"' . $selected . '>' . e($label) . '</option>';
- }
- form_group('payment_method', 'Ödeme Yöntemi', "<select name='payment_method' id='payment_method' class='form-select' required>$paymentOptions</select>", '', $errors['payment_method'] ?? '');
-
- $validityValue = $offer['validity_days'] !== null ? (string)(int)$offer['validity_days'] : '';
- form_group('validity_days', 'Teklif Süresi (gün)', "<input type='number' min='1' max='365' class='form-control' id='validity_days' name='validity_days' value='" . e($validityValue) . "'>", '', $errors['validity_days'] ?? '');
- form_group('installment_term', 'Vade', "<input type='text' class='form-control' id='installment_term' name='installment_term' value='" . e($offer['installment_term']) . "'>", '', $errors['installment_term'] ?? '');
-?>
-<div class="d-flex justify-content-end gap-2">
-  <a href="quotation_view.php?id=<?= (int)$id ?>" class="btn btn-secondary">İptal</a>
-  <button type="submit" class="btn btn-primary">Kaydet</button>
-</div>
+  <?php if (!empty($errors['form'])): ?><div class="alert alert-danger"><?= e($errors['form']) ?></div><?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Müşteri</label>
+    <select name="customer_id" class="form-select <?= isset($errors['customer_id'])?'is-invalid':'' ?>" required>
+      <option value="">Seçiniz</option>
+      <?php foreach ($customers as $c): $label = trim(($c['first_name'] ?? '') . ' ' . ($c['last_name'] ?? '')); if (!empty($c['company'])) $label .= ' (' . $c['company'] . ')'; ?>
+      <option value="<?= (int)$c['id'] ?>" <?= ((int)$offer['customer_id'] === (int)$c['id'])?'selected':'' ?>><?= e($label) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <?php if(isset($errors['customer_id'])): ?><div class="invalid-feedback"><?= e($errors['customer_id']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Montaj Tipi</label>
+    <select name="assembly_type" class="form-select <?= isset($errors['assembly_type'])?'is-invalid':'' ?>" required>
+      <option value="">Seçiniz</option>
+      <?php foreach ($assemblyTypes as $key=>$label): ?>
+      <option value="<?= e($key) ?>" <?= $offer['assembly_type']===$key?'selected':'' ?>><?= e($label) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <?php if(isset($errors['assembly_type'])): ?><div class="invalid-feedback"><?= e($errors['assembly_type']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Yöntemi</label>
+    <select name="payment_method" class="form-select <?= isset($errors['payment_method'])?'is-invalid':'' ?>" required>
+      <option value="">Seçiniz</option>
+      <?php foreach ($paymentLabels as $key=>$label): ?>
+      <option value="<?= e($key) ?>" <?= $offer['payment_method']===$key?'selected':'' ?>><?= e($label) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <?php if(isset($errors['payment_method'])): ?><div class="invalid-feedback"><?= e($errors['payment_method']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3 vadeli-fields" style="display:none;">
+    <label class="form-label">Vade Süresi (ay)</label>
+    <input type="number" min="1" name="term_months" class="form-control <?= isset($errors['term_months'])?'is-invalid':'' ?>" value="<?= e($offer['term_months'] !== null ? (string)(int)$offer['term_months'] : '') ?>">
+    <?php if(isset($errors['term_months'])): ?><div class="invalid-feedback"><?= e($errors['term_months']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3 vadeli-fields" style="display:none;">
+    <label class="form-label">Vade Farkı (aylık)</label>
+    <input type="number" step="0.01" name="interest_value" class="form-control <?= isset($errors['interest_value'])?'is-invalid':'' ?>" value="<?= e($offer['interest_value']) ?>">
+    <?php if(isset($errors['interest_value'])): ?><div class="invalid-feedback"><?= e($errors['interest_value']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Teklif Süresi (gün)</label>
+    <input type="number" min="1" max="365" name="validity_days" class="form-control <?= isset($errors['validity_days'])?'is-invalid':'' ?>" value="<?= e($offer['validity_days'] !== null ? (string)(int)$offer['validity_days'] : '') ?>" placeholder="örn. 15">
+    <?php if(isset($errors['validity_days'])): ?><div class="invalid-feedback"><?= e($errors['validity_days']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3 installment-field">
+    <label class="form-label">Vade</label>
+    <input type="text" name="installment_term" class="form-control <?= isset($errors['installment_term'])?'is-invalid':'' ?>" value="<?= e($offer['installment_term'] ?? '') ?>" placeholder="3 taksit (aylık)">
+    <?php if(isset($errors['installment_term'])): ?><div class="invalid-feedback"><?= e($errors['installment_term']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Teklif Tarihi</label>
+    <input type="date" name="offer_date" class="form-control <?= isset($errors['offer_date'])?'is-invalid':'' ?>" value="<?= e($offer['offer_date']) ?>" required>
+    <?php if(isset($errors['offer_date'])): ?><div class="invalid-feedback"><?= e($errors['offer_date']) ?></div><?php endif; ?>
+  </div>
+  <div class="d-flex justify-content-end gap-2">
+    <a href="quotation_view.php?id=<?= (int)$id ?>" class="btn btn-secondary">İptal</a>
+    <button type="submit" class="btn btn-primary">Kaydet</button>
+  </div>
 </form>
+<script>
+function toggleVadeliFields() {
+  var payment = document.querySelector('select[name="payment_method"]').value;
+  document.querySelectorAll('.vadeli-fields').forEach(function(el){
+    el.style.display = payment === 'vadeli' ? '' : 'none';
+  });
+  var inst = document.querySelector('.installment-field');
+  if (inst) inst.style.display = payment === 'vadeli' ? 'none' : '';
+}
+document.querySelector('select[name="payment_method"]').addEventListener('change', toggleVadeliFields);
+toggleVadeliFields();
+</script>
 <?php require __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Match `quotation_edit.php` fields and validation with the add modal in `quotations.php`
- Support `Vadeli` payment option with term and interest fields
- Add client-side toggle logic for conditional fields

## Testing
- `php -l quotation_edit.php`
- `php -l quotations.php`


------
https://chatgpt.com/codex/tasks/task_e_689c9464ea208328ab7ba37370f5920c