### PR TITLE
Hide unit value field for Kumanda products

### DIFF
--- a/products.php
+++ b/products.php
@@ -69,8 +69,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
       } else {
         $channel_count = (int)$channel_count;
       }
+      $unit_value = null;
     } else {
       $channel_count = null;
+      if ($unit_value <= 0) {
+        $errors[] = 'Birim değeri > 0 olmalıdır.';
+      }
     }
 
     if ($category === '' || !in_array($category, $categoryOptions, true)) {
@@ -78,9 +82,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
     }
     if ($unit_type === '' || !in_array($unit_type, $unitTypeOptions, true)) {
       $errors[] = 'Birim türü seçilmelidir.';
-    }
-    if ($unit_value <= 0) {
-      $errors[] = 'Birim değeri > 0 olmalıdır.';
     }
 
     $color = trim($_POST['color'] ?? '');
@@ -184,8 +185,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
       } else {
         $channel_count = (int)$channel_count;
       }
+      $unit_value = null;
     } else {
       $channel_count = null;
+      if ($unit_value <= 0) {
+        $errors[] = 'Birim değeri > 0 olmalıdır.';
+      }
     }
     $color = trim($_POST['color'] ?? '');
     $description = trim($_POST['description'] ?? '');
@@ -197,9 +202,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $role === 'admin') {
     }
     if ($unit_type === '' || !in_array($unit_type, $unitTypeOptions, true)) {
       $errors[] = 'Birim türü seçilmelidir.';
-    }
-    if ($unit_value <= 0) {
-      $errors[] = 'Birim değeri > 0 olmalıdır.';
     }
     if ($vat_rate === '') {
       $vat_rate = null;
@@ -441,9 +443,9 @@ require __DIR__ . '/header.php';
                               <?php endforeach; ?>
                             </select>
                           </div>
-                          <div class="col-md-6">
+                          <div class="col-md-6 unit-value-group">
                             <label class="form-label">Birim Değeri *</label>
-                            <input type="number" step="0.001" min="0.001" name="unit_value" class="form-control" required value="<?= e($p['unit_value']) ?>">
+                            <input type="number" step="0.001" min="0.001" name="unit_value" class="form-control unit-value-field" required value="<?= e($p['unit_value']) ?>">
                           </div>
                           <div class="col-md-6">
                             <label class="form-label">Renk</label>
@@ -583,10 +585,10 @@ require __DIR__ . '/header.php';
                     <?php endforeach; ?>
                   </select>
                 </div>
-                <div class="col-md-6">
-                  <label class="form-label">Birim Değeri *</label>
-                  <input type="number" step="0.001" min="0.001" name="unit_value" class="form-control" required value="<?= e($_POST['unit_value'] ?? '') ?>">
-                </div>
+                  <div class="col-md-6 unit-value-group">
+                    <label class="form-label">Birim Değeri *</label>
+                    <input type="number" step="0.001" min="0.001" name="unit_value" class="form-control unit-value-field" required value="<?= e($_POST['unit_value'] ?? '') ?>">
+                  </div>
                 <div class="col-md-6">
                   <label class="form-label">Renk</label>
                   <input type="text" name="color" class="form-control">

--- a/public/js/product_form.js
+++ b/public/js/product_form.js
@@ -5,17 +5,28 @@
   }
   document.querySelectorAll('form').forEach(function(form){
     var category = form.querySelector('.category-select');
-    var group = form.querySelector('.channel-count-group');
-    var field = form.querySelector('.channel-count-field');
-    if(!category || !group || !field) return;
+    var channelGroup = form.querySelector('.channel-count-group');
+    var channelField = form.querySelector('.channel-count-field');
+    var unitGroup = form.querySelector('.unit-value-group');
+    var unitField = form.querySelector('.unit-value-field');
+    if(!category) return;
     function sync(){
       var opt = category.options[category.selectedIndex];
       var label = opt ? opt.textContent : '';
-      var show = isKumanda(label);
-      group.classList.toggle('d-none', !show);
-      field.disabled = !show;
-      if(!show){
-        field.value = '';
+      var isK = isKumanda(label);
+      if(channelGroup && channelField){
+        channelGroup.classList.toggle('d-none', !isK);
+        channelField.disabled = !isK;
+        if(!isK){
+          channelField.value = '';
+        }
+      }
+      if(unitGroup && unitField){
+        unitGroup.classList.toggle('d-none', isK);
+        unitField.disabled = isK;
+        if(isK){
+          unitField.value = '';
+        }
       }
     }
     category.addEventListener('change', sync);


### PR DESCRIPTION
## Summary
- Hide "Birim Değeri" field when category is set to Kumanda
- Skip unit value validation and storage for Kumanda products
- Toggle unit value visibility via updated JavaScript

## Testing
- `php -l products.php`
- `node --check public/js/product_form.js`


------
https://chatgpt.com/codex/tasks/task_e_689cb3eba40883289351552aac4d688c