### PR TITLE
Hide unit value input unless kg/m

### DIFF
--- a/products.php
+++ b/products.php
@@ -441,7 +441,7 @@ require __DIR__ . '/header.php';
                               <?php endforeach; ?>
                             </select>
                           </div>
-                          <div class="col-md-6">
+                          <div class="col-md-6 unit-value-group">
                             <label class="form-label">Birim Değeri *</label>
                             <input type="number" step="0.001" min="0.001" name="unit_value" class="form-control" required value="<?= e($p['unit_value']) ?>">
                           </div>
@@ -583,7 +583,7 @@ require __DIR__ . '/header.php';
                     <?php endforeach; ?>
                   </select>
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-6 unit-value-group">
                   <label class="form-label">Birim Değeri *</label>
                   <input type="number" step="0.001" min="0.001" name="unit_value" class="form-control" required value="<?= e($_POST['unit_value'] ?? '') ?>">
                 </div>
@@ -678,6 +678,20 @@ require __DIR__ . '/header.php';
         fileInput.dispatchEvent(new Event('change'));
       }
     });
+  });
+
+  document.querySelectorAll('select[name="unit_type"]').forEach(select => {
+    const unitGroup = select.closest('form')?.querySelector('.unit-value-group');
+    const unitInput = unitGroup?.querySelector('input[name="unit_value"]');
+
+    const toggleUnitValue = () => {
+      const show = select.value === 'kg/m';
+      if (unitGroup) unitGroup.style.display = show ? '' : 'none';
+      if (unitInput) unitInput.required = show;
+    };
+
+    toggleUnitValue();
+    select.addEventListener('change', toggleUnitValue);
   });
 </script>
 <?php require __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- hide unit value input unless unit type is `kg/m`
- add script to toggle visibility based on selected unit type

## Testing
- `php -l products.php`


------
https://chatgpt.com/codex/tasks/task_e_689cb4e57f3c8328816c7a0d4bd18153