### PR TITLE
Show company info only when available in quotation view

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -482,7 +482,9 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
         <div class="card-body">
             <div class="row mb-2">
                 <div class="col-md-6"><strong>Müşteri:</strong> <?= e(trim($offer['first_name'] . ' ' . $offer['last_name'])) ?></div>
-                <div class="col-md-6"><strong>Firma:</strong> <?= e($offer['company_name'] ?? $offer['customer_company']) ?></div>
+                <?php if (!empty($offer['company_name']) || !empty($offer['customer_company'])): ?>
+                    <div class="col-md-6"><strong>Firma:</strong> <?= e($offer['company_name'] ?? $offer['customer_company']) ?></div>
+                <?php endif; ?>
             </div>
             <div class="row mb-2">
                 <div class="col-md-6"><strong>Teklif Tarihi:</strong> <?= e(date('d.m.Y', strtotime($offer['offer_date']))) ?></div>


### PR DESCRIPTION
## Summary
- Conditionally display the company section in `quotation_view.php` only when a company name exists

## Testing
- `php -l quotation_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689dcce7f3208328b9dc9efa5e7fac08