### PR TITLE
Add print functionality to optimization page

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -62,3 +62,9 @@ input[type=number],
 .form-control[type=number] {
   text-align: left !important;
 }
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+}

--- a/header.php
+++ b/header.php
@@ -29,7 +29,7 @@ $userName = $u['full_name'] ?: ($u['username'] ?? 'User');
 </head>
 <body>
 <a class="visually-hidden-focusable" href="#content">İçeriğe geç</a>
-<nav class="navbar navbar-expand-lg bg-body-secondary shadow-sm" role="navigation">
+<nav class="navbar navbar-expand-lg bg-body-secondary shadow-sm no-print" role="navigation">
   <div class="container">
     <a class="navbar-brand" href="dashboard">TeklifPro</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Menüyü Aç">

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -92,9 +92,6 @@ foreach ($systems as $sys) {
 ?>
 <style>
 @media print {
-    .no-print {
-        display: none !important;
-    }
     .print-cols-3 {
         column-count: 3;
         column-gap: 1rem;
@@ -123,7 +120,7 @@ foreach ($systems as $sys) {
             $unit = $row['qty'] ? $row['length'] / $row['qty'] : 0;
         ?>
             <div class="col">
-                <div class="card h-100">
+                <div class="card h-100 d-flex flex-column">
                     <?php if (!empty($row['image'])): ?>
                         <img src="<?= e($row['image']) ?>" class="card-img-top" style="width: 150px; height: 150px; margin-left: auto; margin-right: auto; display: block;" alt="<?= e($row['name']) ?>">
                     <?php endif; ?>

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -90,14 +90,23 @@ foreach ($systems as $sys) {
     }
 }
 ?>
+<style>
+@media print {
+    .no-print {
+        display: none !important;
+    }
+}
+</style>
 <div class="container py-4">
-    <button type="button" class="btn btn-secondary my-3" onclick="window.close();">Geri Dön</button>
+    <button type="button" class="btn btn-secondary my-3 no-print" onclick="window.close();">Geri Dön</button>
     <div class="mb-3 d-flex justify-content-between align-items-center">
         <h1 class="mb-4">Optimizasyon Sonucu</h1>
-        <a href="pdf/render_optimization_pdf.php?id=<?= e((string)$id) ?>" class="btn btn-secondary ms-2" target="_blank">
-
-            <i class="bi bi-file-earmark-pdf"></i> PDF İndir
-        </a>
+        <div class="no-print">
+            <button type="button" class="btn btn-primary ms-2" onclick="window.print();">Yazdır</button>
+            <a href="pdf/render_optimization_pdf.php?id=<?= e((string)$id) ?>" class="btn btn-secondary ms-2" target="_blank">
+                <i class="bi bi-file-earmark-pdf"></i> PDF İndir
+            </a>
+        </div>
     </div>
 
     <div class="row row-cols-1 row-cols-md-3 g-4">

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -95,6 +95,15 @@ foreach ($systems as $sys) {
     .no-print {
         display: none !important;
     }
+    .print-cols-3 {
+        column-count: 3;
+        column-gap: 1rem;
+        display: block;
+    }
+    .print-cols-3 .col {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
 }
 </style>
 <div class="container py-4">
@@ -109,7 +118,7 @@ foreach ($systems as $sys) {
         </div>
     </div>
 
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row row-cols-1 row-cols-md-3 g-4 print-cols-3">
         <?php foreach ($aggregated as $row):
             $unit = $row['qty'] ? $row['length'] / $row['qty'] : 0;
         ?>


### PR DESCRIPTION
## Summary
- Add print button triggering `window.print()` on the optimization result page
- Hide elements marked with `no-print` during printing

## Testing
- `php -l optimizasyon.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689ece4038b083289dcf5bc24587a89c