### PR TITLE
Handle category-specific units in optimization PDF

### DIFF
--- a/pdf/render_optimization_pdf.php
+++ b/pdf/render_optimization_pdf.php
@@ -254,18 +254,26 @@ foreach ($aggregated as $rowData) {
     // Türkçe için daha güvenli küçük harf dönüşümü
     $cat = mb_strtolower((string)($rowData['category'] ?? ''), 'UTF-8');
     $lines = [];
-    if ($cat === 'alüminyum') {
-        $lines[] = 'Birim Uzunluk: ' . (int)round($unit) . ' mm';
-        $lines[] = 'Toplam Uzunluk: ' . (int)round($rowData['length']) . ' mm';
-        $lines[] = 'Adet: ' . $rowData['qty'];
-    } elseif ($cat === 'aksesuar' || $cat === 'fitil') {
-        $lines[] = 'Birim Uzunluk: ' . number_format($unit / 1000, 2, ',', '.') . ' m';
-        $lines[] = 'Toplam Uzunluk: ' . number_format($rowData['length'] / 1000, 2, ',', '.') . ' m';
-    } else {
-        $lines[] = 'Birim Uzunluk: ' . (int)round($unit) . ' mm';
-        $lines[] = 'Toplam Uzunluk: ' . (int)round($rowData['length']) . ' mm';
-        $lines[] = 'Adet: ' . $rowData['qty'];
-        $lines[] = 'Toplam Kg: ' . number_format($rowData['kg'], 3, ',', '.');
+    switch ($cat) {
+        case 'alüminyum':
+            // Alüminyum ürünler ölçü (mm) ve adet cinsinden gösterilir
+            $lines[] = 'Birim Uzunluk: ' . (int)round($unit) . ' mm';
+            $lines[] = 'Toplam Uzunluk: ' . (int)round($rowData['length']) . ' mm';
+            $lines[] = 'Adet: ' . $rowData['qty'];
+            break;
+        case 'aksesuar':
+        case 'fitil':
+            // Aksesuar ve fitil ürünleri metre cinsinden gösterilir
+            $lines[] = 'Birim Uzunluk: ' . number_format($unit / 1000, 2, ',', '.') . ' m';
+            $lines[] = 'Toplam Uzunluk: ' . number_format($rowData['length'] / 1000, 2, ',', '.') . ' m';
+            break;
+        default:
+            // Diğer kategoriler varsayılan olarak mm ve adet cinsinden gösterilir
+            $lines[] = 'Birim Uzunluk: ' . (int)round($unit) . ' mm';
+            $lines[] = 'Toplam Uzunluk: ' . (int)round($rowData['length']) . ' mm';
+            $lines[] = 'Adet: ' . $rowData['qty'];
+            $lines[] = 'Toplam Kg: ' . number_format($rowData['kg'], 3, ',', '.');
+            break;
     }
     foreach ($lines as $line) {
         $pdf->SetX($x + 2);


### PR DESCRIPTION
## Summary
- Show aluminum products in millimeters and include quantity
- Display accessory and gasket categories in meters
- Retain default handling for other categories

## Testing
- `php -l pdf/render_optimization_pdf.php`


------
https://chatgpt.com/codex/tasks/task_e_689f3211bf608328a1e4d0f9c03a9372