### PR TITLE
Add sortable customer list

### DIFF
--- a/customer.php
+++ b/customer.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 require __DIR__ . '/header.php';
 require __DIR__ . '/components/page_header.php';
-require __DIR__ . '/components/data_table.php';
 $pdo->exec('SET NAMES utf8mb4 COLLATE utf8mb4_turkish_ci');
 
 if (empty($_SESSION['csrf_token'])) {
@@ -28,6 +27,28 @@ $page = max(1, (int)($_GET['page'] ?? 1));
 $limit = 10;
 $offset = ($page - 1) * $limit;
 
+$headers = [
+    ['label' => 'İsim',          'key' => 'name'],
+    ['label' => 'Şirket',        'key' => 'company_name'],
+    ['label' => 'Email',         'key' => 'email'],
+    ['label' => 'Telefon',       'key' => 'phone'],
+    ['label' => 'Kayıt Tarihi',  'key' => 'registration_date'],
+    ['label' => 'İşlemler',      'key' => null],
+];
+$allowedSorts = [
+    'id'               => 'id',
+    'name'             => 'first_name',
+    'company_name'     => 'company_name',
+    'email'            => 'email',
+    'phone'            => 'phone',
+    'registration_date'=> 'registration_date',
+];
+$sort = $_GET['sort'] ?? 'id';
+$dirParam = strtolower($_GET['dir'] ?? 'desc');
+$dir = $dirParam === 'asc' ? 'ASC' : 'DESC';
+if (!array_key_exists($sort, $allowedSorts)) { $sort = 'id'; }
+$orderSql = $allowedSorts[$sort] . ' ' . $dir;
+
 try { $hasDate = $pdo->query("SHOW COLUMNS FROM customers LIKE 'created_at'")->rowCount() > 0; } catch (Exception $e) { $hasDate = false; }
 $sql = 'SELECT id, first_name, last_name, company_name, email, phone';
 $sql .= $hasDate ? ', created_at AS registration_date' : ', NULL AS registration_date';
@@ -37,7 +58,7 @@ if ($search !== '') {
     $sql .= ' WHERE first_name LIKE :term OR last_name LIKE :term OR company_name LIKE :term OR email LIKE :term OR phone LIKE :term';
     $params['term'] = "%$search%";
 }
-$sql .= ' ORDER BY id DESC LIMIT :limit OFFSET :offset';
+$sql .= ' ORDER BY ' . $orderSql . ' LIMIT :limit OFFSET :offset';
 $stmt = $pdo->prepare($sql);
 foreach ($params as $key => $value) { $stmt->bindValue($key, $value, PDO::PARAM_STR); }
 $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
@@ -60,12 +81,35 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
 <?php if ($success): ?><div class="alert alert-success" role="alert"><?= htmlspecialchars($success, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
 <?php if ($error): ?><div class="alert alert-danger" role="alert"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div><?php endif; ?>
 <form class="mb-3" method="get" role="search">
+  <input type="hidden" name="sort" value="<?= htmlspecialchars($sort, ENT_QUOTES, 'UTF-8'); ?>">
+  <input type="hidden" name="dir" value="<?= htmlspecialchars($dirParam, ENT_QUOTES, 'UTF-8'); ?>">
   <div class="input-group">
     <input type="search" name="search" class="form-control" placeholder="Ara" value="<?= htmlspecialchars($search, ENT_QUOTES, 'UTF-8'); ?>">
     <button class="btn btn-outline-secondary" type="submit"><i class="bi bi-search"></i></button>
   </div>
 </form>
-<?php data_table_start(['İsim','Şirket','Email','Telefon','Kayıt Tarihi','İşlemler'], 'text-center'); ?>
+<div class="table-responsive">
+<table class="table table-hover align-middle">
+  <thead class="table-light sticky-top">
+    <tr class="text-center">
+      <?php foreach ($headers as $h): ?>
+        <th scope="col">
+          <?= htmlspecialchars($h['label'], ENT_QUOTES, 'UTF-8'); ?>
+          <?php if ($h['key']):
+            $isCurrent = $sort === $h['key'];
+            $nextDir = ($isCurrent && $dirParam === 'asc') ? 'desc' : 'asc';
+            $icon = 'bi-arrow-down-up';
+            if ($isCurrent) {
+              $icon = $dirParam === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill';
+            }
+          ?>
+            <a href="?<?= htmlspecialchars(http_build_query(array_merge($_GET, ['sort'=>$h['key'],'dir'=>$nextDir,'page'=>1])), ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-link p-0"><i class="bi <?= $icon ?>"></i></a>
+          <?php endif; ?>
+        </th>
+      <?php endforeach; ?>
+    </tr>
+  </thead>
+  <tbody>
 <?php if ($customers): foreach ($customers as $cust): ?>
 <tr class="text-center" data-id="<?= (int)$cust['id']; ?>">
   <td class="col-name"><?= htmlspecialchars(trim(($cust['first_name'] ?? '') . ' ' . ($cust['last_name'] ?? '')), ENT_QUOTES, 'UTF-8'); ?></td>
@@ -84,11 +128,13 @@ $error = $error ?? filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHAR
 <?php endforeach; else: ?>
 <tr><td colspan="6" class="text-center text-muted">Müşteri bulunamadı.</td></tr>
 <?php endif; ?>
-<?php data_table_end(); ?>
+  </tbody>
+</table>
+</div>
 <?php if ($totalPages > 1): ?>
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
-    <?php for ($i = 1; $i <= $totalPages; $i++): $query = http_build_query(['page'=>$i,'search'=>$search]); ?>
+    <?php for ($i = 1; $i <= $totalPages; $i++): $query = http_build_query(['page'=>$i,'search'=>$search,'sort'=>$sort,'dir'=>$dirParam]); ?>
       <li class="page-item<?= $i === $page ? ' active' : ''; ?>"><a class="page-link" href="customer?<?= htmlspecialchars($query, ENT_QUOTES, 'UTF-8'); ?>"><?= $i; ?></a></li>
     <?php endfor; ?>
   </ul>


### PR DESCRIPTION
## Summary
- add server-side sorting parameters for customers
- render sortable table headers and preserve sorting across search and pagination

## Testing
- `php -l customer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a039895ec08328b5abd48ff0797308