### PR TITLE
Add cost breakdown view for guillotine offers

### DIFF
--- a/guillotine_optimize_view.php
+++ b/guillotine_optimize_view.php
@@ -57,7 +57,7 @@ function computeSystem(array $row, PDO $pdo, array &$alerts): array {
         ['label' => 'Motor Kutusu',          'name' => 'Motor Kutusu',  'measure' => fn($w,$h,$q) => $w - 14,                                            'qty' => fn($w,$h,$q) => $q],
         ['label' => 'Motor Kapak',           'name' => 'Motor Kapak',   'measure' => fn($w,$h,$q) => $w - 15,                                            'qty' => fn($w,$h,$q) => $q],
         ['label' => 'Alt Kasa',              'name' => 'Alt Kasa',      'measure' => fn($w,$h,$q) => $w,                                                 'qty' => fn($w,$h,$q) => $q],
-        ['label' => 'Tutamak',               'name' => 'Tutamak',       'measure' => fn($w,$h,$q) => $w - 185,                                           'qty' => fn($w,$h,$q) => 6*$q],
+        ['label' => 'Tutamak',               'name' => 'Tutamak',       'measure' => fn($w,$h,$q) => $w - 185,                                           'qty' => fn($w,$h,$q) => $q],
         ['label' => 'Kenetli Baza',          'name' => 'Kenetli Baza',  'measure' => fn($w,$h,$q) => $w - 185,                                           'qty' => fn($w,$h,$q) => 3*$q],
         ['label' => 'Küpeşte Bazası',        'name' => 'Küpeşte Bazası',  'measure' => fn($w,$h,$q) => $w - 185,                                           'qty' => fn($w,$h,$q) => 2*$q],
         ['label' => 'Küpeşte',               'name' => 'Küpeşte',       'measure' => fn($w,$h,$q) => $w - 185,                                           'qty' => fn($w,$h,$q) => $q],

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -65,8 +65,11 @@ function calculateGuillotineTotals(PDO $pdo, array $row): array
 
     $pStmt = $pdo->prepare('SELECT unit, unit_price, vat_rate, weight_per_meter, category FROM products WHERE LOWER(name) = LOWER(:name)');
 
-    $base       = 0.0;
-    $aluminumKg = 0.0;
+    $base          = 0.0;
+    $aluminumKg    = 0.0;
+    $aluminumCost  = 0.0;
+    $glassCost     = 0.0;
+    $laborCost     = 0.0;
     foreach ($rules as $rule) {
         $measure = max(0, $rule['measure']($width, $height, $qty));
         $rq = max(0, $rule['qty']($width, $height, $qty));
@@ -80,6 +83,7 @@ function calculateGuillotineTotals(PDO $pdo, array $row): array
             $unitPriceVat = $unitPrice * (1 + $vatRate / 100);
             $unit = strtolower($p['unit'] ?? '');
             $lineTotal = 0.0;
+            $kg = 0.0;
             switch ($unit) {
                 case 'kilogram':
                 case 'kg':
@@ -110,21 +114,36 @@ function calculateGuillotineTotals(PDO $pdo, array $row): array
                     $lineTotal = $rq * $unitPriceVat;
             }
             $base += $lineTotal;
+            $cat = strtolower((string)($p['category'] ?? ''));
+            if ($cat === 'alüminyum') {
+                $aluminumCost += $lineTotal;
+            } elseif ($cat === 'cam') {
+                $glassCost += $lineTotal;
+            }
         }
     }
 
     // Additional cost items
-    $kgBoyalı = $aluminumKg * 1.01; // Alüminyum Boyalı kg
-    $base += $kgBoyalı * 200;       // Alüminyum Boyalı toplamı
-    $base += $kgBoyalı * 0.07 * 200; // Alüminyum Fire toplamı
+    $kgBoyalı       = $aluminumKg * 1.01; // Alüminyum Boyalı kg
+    $alPaint        = $kgBoyalı * 200;    // Alüminyum Boyalı toplamı
+    $alWaste        = $kgBoyalı * 0.07 * 200; // Alüminyum Fire toplamı
+    $base          += $alPaint + $alWaste;
+    $aluminumCost  += $alPaint + $alWaste;
 
-    $area = ($width * $height * $qty) / 1000000; // m²
-    $base += $area * 40; // İmalat İşçiliği
+    $area      = ($width * $height * $qty) / 1000000; // m²
+    $laborCost = $area * 40; // İmalat İşçiliği
+    $base     += $laborCost;
 
     $rate   = (float)($row['profit_rate'] ?? $row['profit_margin'] ?? 0);
     $profit = $base * ($rate / 100);
     $total  = $base + $profit;
-    return ['profit' => $profit, 'total' => $total];
+    $breakdown = [
+        'Cam Maliyeti'       => $glassCost,
+        'Alüminyum Maliyeti' => $aluminumCost,
+        'İşçilik'            => $laborCost,
+        'Kâr Marjı'          => $profit,
+    ];
+    return ['profit' => $profit, 'total' => $total, 'breakdown' => $breakdown];
 }
 
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
@@ -535,6 +554,7 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                                     <td><?= e($g['ral_code']) ?></td>
                                     <td class="text-end"><?= e(number_format((float)$g['total_amount'], 2, ',', '.')) ?> ₺</td>
                                     <td class="text-end">
+                                        <a href="test.php?id=<?= e((string)$g['id']) ?>" class="btn btn-sm btn-info" target="_blank">Kalemler</a>
                                         <button type="button" class="btn btn-sm btn-secondary edit-guillotine" data-bs-toggle="modal" data-bs-target="#addGuillotineModal"
                                             data-id="<?= e((string)$g['id']) ?>"
                                             data-width="<?= e((string)$g['width']) ?>"

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -554,7 +554,7 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                                     <td><?= e($g['ral_code']) ?></td>
                                     <td class="text-end"><?= e(number_format((float)$g['total_amount'], 2, ',', '.')) ?> ₺</td>
                                     <td class="text-end">
-                                        <a href="test.php?id=<?= e((string)$g['id']) ?>" class="btn btn-sm btn-info" target="_blank">Kalemler</a>
+                                        <a href="test.php?quote_id=<?= e((string)$g['id']) ?>" class="btn btn-sm btn-info">Kalemler</a>
                                         <button type="button" class="btn btn-sm btn-secondary edit-guillotine" data-bs-toggle="modal" data-bs-target="#addGuillotineModal"
                                             data-id="<?= e((string)$g['id']) ?>"
                                             data-width="<?= e((string)$g['width']) ?>"

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -45,7 +45,7 @@ function calculateGuillotineTotals(PDO $pdo, array $row): array
         ['name' => 'Motor Kutusu',       'measure' => fn($w,$h,$q) => $w - 14,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Motor Kapak',        'measure' => fn($w,$h,$q) => $w - 15,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Alt Kasa',           'measure' => fn($w,$h,$q) => $w,                              'qty' => fn($w,$h,$q) => $q],
-        ['name' => 'Tutamak',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 6*$q],
+        ['name' => 'Tutamak',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Kenetli Baza',       'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 3*$q],
         ['name' => 'Küpeşte Bazası',     'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 2*$q],
         ['name' => 'Küpeşte',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],

--- a/test.php
+++ b/test.php
@@ -36,7 +36,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
         ['name' => 'Motor Kutusu',        'measure' => fn($w,$h,$q) => $w - 14,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Motor Kapak',         'measure' => fn($w,$h,$q) => $w - 15,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Alt Kasa',            'measure' => fn($w,$h,$q) => $w,                              'qty' => fn($w,$h,$q) => $q],
-        ['name' => 'Tutamak',             'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 6*$q],
+        ['name' => 'Tutamak',             'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Kenetli Baza',        'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 3*$q],
         ['name' => 'Küpeşte Bazası',      'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 2*$q],
         ['name' => 'Küpeşte',             'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],

--- a/test.php
+++ b/test.php
@@ -6,6 +6,26 @@ function e(?string $v): string
     return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
 }
 
+function fmt_try(float $v): string
+{
+    return number_format($v, 2, ',', '.');
+}
+
+function fmt_qty(float $v, string $unit): string
+{
+    $unit = strtolower(trim($unit));
+    $decimals = in_array($unit, ['kg', 'kilogram', 'kg/m', 'm', 'metre', 'm²', 'm2'], true) ? 3 : 2;
+    return number_format($v, $decimals, ',', '.');
+}
+
+function fmt_measure($v, string $unit): string
+{
+    if (!is_numeric($v)) {
+        return '-';
+    }
+    return fmt_qty((float)$v, $unit);
+}
+
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
@@ -221,15 +241,15 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
                         <tr>
                             <td><?= e($label) ?></td>
                             <td><?= e($item['name']) ?></td>
-                            <td class="text-end"><?= e(is_numeric($item['measure']) ? number_format((float)$item['measure'], 2, ',', '.') : '-') ?></td>
-                            <td><?= e($item['unit']) ?></td>
-                            <td class="text-end"><?= e(number_format($item['quantity'], 2, ',', '.')) ?></td>
-                            <td class="text-end"><?= e(number_format($item['total'], 2, ',', '.')) ?> ₺</td>
+                              <td class="text-end"><?= e(fmt_measure($item['measure'], $item['unit'])) ?></td>
+                              <td><?= e($item['unit']) ?></td>
+                              <td class="text-end"><?= e(fmt_qty($item['quantity'], $item['unit'])) ?></td>
+                              <td class="text-end"><?= e(fmt_try($item['total'])) ?> ₺</td>
                         </tr>
                     <?php endforeach; ?>
                     <tr class="table-light">
                         <th colspan="5" class="text-end">Toplam <?= e($label) ?></th>
-                        <th class="text-end"><?= e(number_format($catTotals[$label] ?? 0, 2, ',', '.')) ?> ₺</th>
+                          <th class="text-end"><?= e(fmt_try($catTotals[$label] ?? 0)) ?> ₺</th>
                     </tr>
                 <?php endif; ?>
             <?php endforeach; ?>
@@ -237,7 +257,7 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
             <tfoot>
                 <tr>
                     <th colspan="5">Genel Toplam</th>
-                    <th class="text-end"><?= e(number_format($total, 2, ',', '.')) ?> ₺</th>
+                      <th class="text-end"><?= e(fmt_try($total)) ?> ₺</th>
                 </tr>
             </tfoot>
         </table>

--- a/test.php
+++ b/test.php
@@ -128,6 +128,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
             $items[] = [
                 'category' => $cat,
                 'name'     => $rule['name'],
+                'measure'  => $measure,
                 'unit'     => $unitRaw,
                 'quantity' => $qtyDisplay,
                 'total'    => $lineTotal,
@@ -145,6 +146,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $items[] = [
         'category' => 'Alüminyum Boyalı',
         'name'     => 'Alüminyum Boyalı',
+        'measure'  => null,
         'unit'     => 'kg',
         'quantity' => $kgPainted,
         'total'    => $alPaintCost,
@@ -152,6 +154,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $items[] = [
         'category' => 'Alüminyum Fire',
         'name'     => 'Alüminyum Fire',
+        'measure'  => null,
         'unit'     => 'kg',
         'quantity' => $alWasteQty,
         'total'    => $alWasteCost,
@@ -164,6 +167,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $items[] = [
         'category' => 'İşçilik',
         'name'     => 'İşçilik',
+        'measure'  => null,
         'unit'     => 'm²',
         'quantity' => $area,
         'total'    => $laborCost,
@@ -176,6 +180,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $items[] = [
         'category' => 'Diğer',
         'name'     => 'Kâr',
+        'measure'  => null,
         'unit'     => '',
         'quantity' => 1,
         'total'    => $profit,
@@ -203,6 +208,7 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
                 <tr>
                     <th>Kategori</th>
                     <th>Kalem</th>
+                    <th class="text-end">Ölçü</th>
                     <th>Birim</th>
                     <th class="text-end">Birim Değeri</th>
                     <th class="text-end">Tutar (₺)</th>
@@ -215,13 +221,14 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
                         <tr>
                             <td><?= e($label) ?></td>
                             <td><?= e($item['name']) ?></td>
+                            <td class="text-end"><?= e(is_numeric($item['measure']) ? number_format((float)$item['measure'], 2, ',', '.') : '-') ?></td>
                             <td><?= e($item['unit']) ?></td>
                             <td class="text-end"><?= e(number_format($item['quantity'], 2, ',', '.')) ?></td>
                             <td class="text-end"><?= e(number_format($item['total'], 2, ',', '.')) ?> ₺</td>
                         </tr>
                     <?php endforeach; ?>
                     <tr class="table-light">
-                        <th colspan="4" class="text-end">Toplam <?= e($label) ?></th>
+                        <th colspan="5" class="text-end">Toplam <?= e($label) ?></th>
                         <th class="text-end"><?= e(number_format($catTotals[$label] ?? 0, 2, ',', '.')) ?> ₺</th>
                     </tr>
                 <?php endif; ?>
@@ -229,7 +236,7 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
             </tbody>
             <tfoot>
                 <tr>
-                    <th colspan="4">Genel Toplam</th>
+                    <th colspan="5">Genel Toplam</th>
                     <th class="text-end"><?= e(number_format($total, 2, ',', '.')) ?> ₺</th>
                 </tr>
             </tfoot>

--- a/test.php
+++ b/test.php
@@ -57,6 +57,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $pStmt = $pdo->prepare('SELECT unit, unit_price, vat_rate, weight_per_meter, category FROM products WHERE LOWER(name) = LOWER(:name)');
 
     $categoryTotals = [];
+    $items       = [];
     $base        = 0.0;
     $aluminumKg  = 0.0;
 
@@ -68,12 +69,14 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
         }
         $pStmt->execute([':name' => $rule['name']]);
         if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
-            $unitPrice   = (float)($p['unit_price'] ?? 0);
-            $vatRate     = (float)($p['vat_rate'] ?? 0);
+            $unitPrice    = (float)($p['unit_price'] ?? 0);
+            $vatRate      = (float)($p['vat_rate'] ?? 0);
             $unitPriceVat = $unitPrice * (1 + $vatRate / 100);
-            $unit        = strtolower($p['unit'] ?? '');
-            $lineTotal   = 0.0;
-            $kg          = 0.0;
+            $unitRaw      = (string)($p['unit'] ?? '');
+            $unit         = strtolower($unitRaw);
+            $lineTotal    = 0.0;
+            $qtyDisplay   = 0.0;
+            $kg           = 0.0;
             switch ($unit) {
                 case 'kilogram':
                 case 'kg':
@@ -84,21 +87,25 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
                     }
                     $meters    = ($measure / 1000) * $rq;
                     $kg        = $meters * $wpm;
-                    $lineTotal = $kg * $unitPriceVat;
+                    $qtyDisplay = $kg;
+                    $lineTotal  = $kg * $unitPriceVat;
                     break;
                 case 'metre':
                 case 'm':
-                    $meters    = ($measure / 1000) * $rq;
-                    $lineTotal = $meters * $unitPriceVat;
+                    $meters     = ($measure / 1000) * $rq;
+                    $qtyDisplay = $meters;
+                    $lineTotal  = $meters * $unitPriceVat;
                     break;
                 case 'metrekare':
                 case 'm²':
                 case 'm2':
-                    $area      = ($width * $height / 1000000) * $rq;
-                    $lineTotal = $area * $unitPriceVat;
+                    $area       = ($width * $height / 1000000) * $rq;
+                    $qtyDisplay = $area;
+                    $lineTotal  = $area * $unitPriceVat;
                     break;
                 default:
-                    $lineTotal = $rq * $unitPriceVat;
+                    $qtyDisplay = $rq;
+                    $lineTotal  = $rq * $unitPriceVat;
             }
             $base += $lineTotal;
             $cat = trim((string)($p['category'] ?? ''));
@@ -107,6 +114,13 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
             if (strtolower($cat) === 'alüminyum') {
                 $aluminumKg += $kg;
             }
+            $items[] = [
+                'category' => $cat,
+                'name'     => $rule['name'],
+                'unit'     => $unitRaw,
+                'quantity' => $qtyDisplay,
+                'total'    => $lineTotal,
+            ];
         }
     }
 
@@ -115,23 +129,48 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $alWaste   = $kgPainted * 0.07 * 200;
     $base     += $alPaint + $alWaste;
     $categoryTotals['Alüminyum'] = ($categoryTotals['Alüminyum'] ?? 0) + $alPaint + $alWaste;
+    $items[] = [
+        'category' => 'Alüminyum',
+        'name'     => 'Boya + Fire',
+        'unit'     => 'kg',
+        'quantity' => $kgPainted,
+        'total'    => $alPaint + $alWaste,
+    ];
 
     $area      = ($width * $height * $qty) / 1000000;
     $laborCost = $area * 40;
     $base     += $laborCost;
     $categoryTotals['İşçilik'] = ($categoryTotals['İşçilik'] ?? 0) + $laborCost;
+    $items[] = [
+        'category' => 'İşçilik',
+        'name'     => 'İşçilik',
+        'unit'     => 'm²',
+        'quantity' => $area,
+        'total'    => $laborCost,
+    ];
 
     $rate   = (float)($row['profit_rate'] ?? $row['profit_margin'] ?? 0);
     $profit = $base * ($rate / 100);
     $total  = $base + $profit;
     $categoryTotals['Diğer'] = ($categoryTotals['Diğer'] ?? 0) + $profit;
+    $items[] = [
+        'category' => 'Diğer',
+        'name'     => 'Kâr',
+        'unit'     => '',
+        'quantity' => 1,
+        'total'    => $profit,
+    ];
 
-    return ['categories' => $categoryTotals, 'total' => $total];
+    return ['categories' => $categoryTotals, 'items' => $items, 'total' => $total];
 }
 
 $totals = calculateGuillotineCategoryTotals($pdo, $system);
 $orderedCats = ['Alüminyum','Aksesuar','Fitil','Cam','İşçilik','Montaj','Diğer'];
 $catTotals = array_merge(array_fill_keys($orderedCats, 0), $totals['categories']);
+$itemsByCat = [];
+foreach ($totals['items'] as $it) {
+    $itemsByCat[$it['category']][] = $it;
+}
 $total = $totals['total'];
 $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_id'] ?? ''));
 ?>
@@ -143,20 +182,34 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
             <thead>
                 <tr>
                     <th>Kategori</th>
+                    <th>Kalem</th>
+                    <th>Birim</th>
+                    <th class="text-end">Birim Değeri</th>
                     <th class="text-end">Tutar (₺)</th>
                 </tr>
             </thead>
             <tbody>
             <?php foreach ($orderedCats as $label): ?>
-                <tr>
-                    <td><?= e($label) ?></td>
-                    <td class="text-end"><?= e(number_format($catTotals[$label] ?? 0, 2, ',', '.')) ?> ₺</td>
-                </tr>
+                <?php if (!empty($itemsByCat[$label])): ?>
+                    <?php foreach ($itemsByCat[$label] as $item): ?>
+                        <tr>
+                            <td><?= e($label) ?></td>
+                            <td><?= e($item['name']) ?></td>
+                            <td><?= e($item['unit']) ?></td>
+                            <td class="text-end"><?= e(number_format($item['quantity'], 2, ',', '.')) ?></td>
+                            <td class="text-end"><?= e(number_format($item['total'], 2, ',', '.')) ?> ₺</td>
+                        </tr>
+                    <?php endforeach; ?>
+                    <tr class="table-light">
+                        <th colspan="4" class="text-end">Toplam <?= e($label) ?></th>
+                        <th class="text-end"><?= e(number_format($catTotals[$label] ?? 0, 2, ',', '.')) ?> ₺</th>
+                    </tr>
+                <?php endif; ?>
             <?php endforeach; ?>
             </tbody>
             <tfoot>
                 <tr>
-                    <th>Genel Toplam</th>
+                    <th colspan="4">Genel Toplam</th>
                     <th class="text-end"><?= e(number_format($total, 2, ',', '.')) ?> ₺</th>
                 </tr>
             </tfoot>
@@ -164,4 +217,3 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
     </div>
 </div>
 <?php require __DIR__ . '/footer.php'; ?>
-

--- a/test.php
+++ b/test.php
@@ -124,17 +124,25 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
         }
     }
 
-    $kgPainted = $aluminumKg * 1.01;
-    $alPaint   = $kgPainted * 200;
-    $alWaste   = $kgPainted * 0.07 * 200;
-    $base     += $alPaint + $alWaste;
-    $categoryTotals['Alüminyum'] = ($categoryTotals['Alüminyum'] ?? 0) + $alPaint + $alWaste;
+    $kgPainted   = $aluminumKg * 1.01;
+    $alPaintCost = $kgPainted * 200;
+    $alWasteQty  = $kgPainted * 0.07;
+    $alWasteCost = $alWasteQty * 200;
+    $base += $alPaintCost + $alWasteCost;
+    $categoryTotals['Alüminyum'] = ($categoryTotals['Alüminyum'] ?? 0) + $alPaintCost + $alWasteCost;
     $items[] = [
         'category' => 'Alüminyum',
-        'name'     => 'Boya + Fire',
+        'name'     => 'Alüminyum Boyalı',
         'unit'     => 'kg',
         'quantity' => $kgPainted,
-        'total'    => $alPaint + $alWaste,
+        'total'    => $alPaintCost,
+    ];
+    $items[] = [
+        'category' => 'Alüminyum',
+        'name'     => 'Alüminyum Fire',
+        'unit'     => 'kg',
+        'quantity' => $alWasteQty,
+        'total'    => $alWasteCost,
     ];
 
     $area      = ($width * $height * $qty) / 1000000;

--- a/test.php
+++ b/test.php
@@ -17,7 +17,7 @@ function fmtFlex($v, string $unit = '', bool $currency = false): string
     }
     $unit = strtolower(trim($unit));
     if (in_array($unit, ['kg', 'kilogram', 'kg/m', 'm', 'metre', 'm²', 'm2'], true)) {
-        $formatted = number_format($v, 4, ',', '.');
+        $formatted = number_format($v, 3, ',', '.');
     } else {
         $formatted = number_format($v, 2, ',', '.');
     }

--- a/test.php
+++ b/test.php
@@ -10,15 +10,15 @@ if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
 
-$id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-if (!$id) {
+$quoteId = filter_input(INPUT_GET, 'quote_id', FILTER_VALIDATE_INT);
+if (!$quoteId) {
     echo '<div class="container mt-4"><div class="alert alert-danger">Geçersiz giyotin ID.</div></div>';
     require __DIR__ . '/footer.php';
     exit;
 }
 
 $stmt = $pdo->prepare('SELECT * FROM guillotinesystems WHERE id = :id');
-$stmt->execute([':id' => $id]);
+$stmt->execute([':id' => $quoteId]);
 $system = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$system) {
     echo '<div class="container mt-4"><div class="alert alert-danger">Giyotin sistemi bulunamadı.</div></div>';
@@ -26,55 +26,54 @@ if (!$system) {
     exit;
 }
 
-function calculateGuillotineTotals(PDO $pdo, array $row): array
+function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
 {
     $width  = max(0, (float)($row['width'] ?? 0));
     $height = max(0, (float)($row['height'] ?? 0));
     $qty    = max(0, (int)($row['quantity'] ?? 0));
 
     $rules = [
-        ['name' => 'Motor Kutusu',       'measure' => fn($w,$h,$q) => $w - 14,                        'qty' => fn($w,$h,$q) => $q],
-        ['name' => 'Motor Kapak',        'measure' => fn($w,$h,$q) => $w - 15,                        'qty' => fn($w,$h,$q) => $q],
-        ['name' => 'Alt Kasa',           'measure' => fn($w,$h,$q) => $w,                              'qty' => fn($w,$h,$q) => $q],
-        ['name' => 'Tutamak',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 6*$q],
-        ['name' => 'Kenetli Baza',       'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 3*$q],
-        ['name' => 'Küpeşte Bazası',     'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Küpeşte',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Motor Kutusu',        'measure' => fn($w,$h,$q) => $w - 14,                        'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Motor Kapak',         'measure' => fn($w,$h,$q) => $w - 15,                        'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Alt Kasa',            'measure' => fn($w,$h,$q) => $w,                              'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Tutamak',             'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 6*$q],
+        ['name' => 'Kenetli Baza',        'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 3*$q],
+        ['name' => 'Küpeşte Bazası',      'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Küpeşte',             'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Yatay Tek Cam Çıtası','measure' => fn($w,$h,$q) => ($w - 185) - 52,                'qty' => fn($w,$h,$q) => 11*$q],
         ['name' => 'Dikey Tek Cam Çıtası','measure' => fn($w,$h,$q) => (($h - 290) / 3) - 5,           'qty' => fn($w,$h,$q) => 11*$q],
-        ['name' => 'Dikme',              'measure' => fn($w,$h,$q) => $h - 166,                        'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Orta Dikme',         'measure' => fn($w,$h,$q) => $h - 166,                        'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Son Kapatma',        'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221,       'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Kanat',              'measure' => fn($w,$h,$q) => ($h - 290) / 3,                  'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Dikey Baza',         'measure' => fn($w,$h,$q) => ($h - 290) / 3,                  'qty' => fn($w,$h,$q) => 4*$q],
-        ['name' => 'Zincir',             'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600, 'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Flatbelt Kayış',     'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600, 'qty' => fn($w,$h,$q) => 2*$q],
-        ['name' => 'Motor Borusu',       'measure' => fn($w,$h,$q) => $w - 59,                         'qty' => fn($w,$h,$q) => $q],
-        ['name' => 'Motor Kutu Contası', 'measure' => fn($w,$h,$q) => ($w - 14)*$q + $w*$q,            'qty' => fn($w,$h,$q) => 1],
-        ['name' => 'Kanat Contası',      'measure' => fn($w,$h,$q) => (($h - 290)/3)*$q*2,             'qty' => fn($w,$h,$q) => 1],
+        ['name' => 'Dikme',               'measure' => fn($w,$h,$q) => $h - 166,                        'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Orta Dikme',          'measure' => fn($w,$h,$q) => $h - 166,                        'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Son Kapatma',         'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221,       'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Kanat',               'measure' => fn($w,$h,$q) => ($h - 290) / 3,                  'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Dikey Baza',          'measure' => fn($w,$h,$q) => ($h - 290) / 3,                  'qty' => fn($w,$h,$q) => 4*$q],
+        ['name' => 'Zincir',              'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600, 'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Flatbelt Kayış',      'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600, 'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Motor Borusu',        'measure' => fn($w,$h,$q) => $w - 59,                         'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Motor Kutu Contası',  'measure' => fn($w,$h,$q) => ($w - 14)*$q + $w*$q,            'qty' => fn($w,$h,$q) => 1],
+        ['name' => 'Kanat Contası',       'measure' => fn($w,$h,$q) => (($h - 290)/3)*$q*2,             'qty' => fn($w,$h,$q) => 1],
     ];
 
     $pStmt = $pdo->prepare('SELECT unit, unit_price, vat_rate, weight_per_meter, category FROM products WHERE LOWER(name) = LOWER(:name)');
 
-    $base          = 0.0;
-    $aluminumKg    = 0.0;
-    $aluminumCost  = 0.0;
-    $glassCost     = 0.0;
-    $laborCost     = 0.0;
+    $categoryTotals = [];
+    $base        = 0.0;
+    $aluminumKg  = 0.0;
+
     foreach ($rules as $rule) {
         $measure = max(0, $rule['measure']($width, $height, $qty));
-        $rq = max(0, $rule['qty']($width, $height, $qty));
+        $rq      = max(0, $rule['qty']($width, $height, $qty));
         if ($measure <= 0 || $rq <= 0) {
             continue;
         }
         $pStmt->execute([':name' => $rule['name']]);
         if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
-            $unitPrice = (float)($p['unit_price'] ?? 0);
-            $vatRate = (float)($p['vat_rate'] ?? 0);
+            $unitPrice   = (float)($p['unit_price'] ?? 0);
+            $vatRate     = (float)($p['vat_rate'] ?? 0);
             $unitPriceVat = $unitPrice * (1 + $vatRate / 100);
-            $unit = strtolower($p['unit'] ?? '');
-            $lineTotal = 0.0;
-            $kg = 0.0;
+            $unit        = strtolower($p['unit'] ?? '');
+            $lineTotal   = 0.0;
+            $kg          = 0.0;
             switch ($unit) {
                 case 'kilogram':
                 case 'kg':
@@ -83,82 +82,81 @@ function calculateGuillotineTotals(PDO $pdo, array $row): array
                     if ($wpm <= 0) {
                         continue 2;
                     }
-                    $meters = ($measure / 1000) * $rq;
-                    $kg      = $meters * $wpm;
+                    $meters    = ($measure / 1000) * $rq;
+                    $kg        = $meters * $wpm;
                     $lineTotal = $kg * $unitPriceVat;
-                    if (strtolower((string)($p['category'] ?? '')) === 'alüminyum') {
-                        $aluminumKg += $kg;
-                    }
                     break;
                 case 'metre':
                 case 'm':
-                    $meters = ($measure / 1000) * $rq;
+                    $meters    = ($measure / 1000) * $rq;
                     $lineTotal = $meters * $unitPriceVat;
                     break;
                 case 'metrekare':
                 case 'm²':
                 case 'm2':
-                    $area = ($width * $height / 1000000) * $rq;
+                    $area      = ($width * $height / 1000000) * $rq;
                     $lineTotal = $area * $unitPriceVat;
                     break;
                 default:
                     $lineTotal = $rq * $unitPriceVat;
             }
             $base += $lineTotal;
-            $cat = strtolower((string)($p['category'] ?? ''));
-            if ($cat === 'alüminyum') {
-                $aluminumCost += $lineTotal;
-            } elseif ($cat === 'cam') {
-                $glassCost += $lineTotal;
+            $cat = trim((string)($p['category'] ?? ''));
+            $cat = $cat !== '' ? $cat : 'Diğer';
+            $categoryTotals[$cat] = ($categoryTotals[$cat] ?? 0) + $lineTotal;
+            if (strtolower($cat) === 'alüminyum') {
+                $aluminumKg += $kg;
             }
         }
     }
 
-    // Additional cost items
-    $kgBoyalı       = $aluminumKg * 1.01; // Alüminyum Boyalı kg
-    $alPaint        = $kgBoyalı * 200;    // Alüminyum Boyalı toplamı
-    $alWaste        = $kgBoyalı * 0.07 * 200; // Alüminyum Fire toplamı
-    $base          += $alPaint + $alWaste;
-    $aluminumCost  += $alPaint + $alWaste;
+    $kgPainted = $aluminumKg * 1.01;
+    $alPaint   = $kgPainted * 200;
+    $alWaste   = $kgPainted * 0.07 * 200;
+    $base     += $alPaint + $alWaste;
+    $categoryTotals['Alüminyum'] = ($categoryTotals['Alüminyum'] ?? 0) + $alPaint + $alWaste;
 
-    $area      = ($width * $height * $qty) / 1000000; // m²
-    $laborCost = $area * 40; // İmalat İşçiliği
+    $area      = ($width * $height * $qty) / 1000000;
+    $laborCost = $area * 40;
     $base     += $laborCost;
+    $categoryTotals['İşçilik'] = ($categoryTotals['İşçilik'] ?? 0) + $laborCost;
 
     $rate   = (float)($row['profit_rate'] ?? $row['profit_margin'] ?? 0);
     $profit = $base * ($rate / 100);
     $total  = $base + $profit;
-    $breakdown = [
-        'Cam Maliyeti'       => $glassCost,
-        'Alüminyum Maliyeti' => $aluminumCost,
-        'İşçilik'            => $laborCost,
-        'Kâr Marjı'          => $profit,
-    ];
-    return ['profit' => $profit, 'total' => $total, 'breakdown' => $breakdown];
+    $categoryTotals['Diğer'] = ($categoryTotals['Diğer'] ?? 0) + $profit;
+
+    return ['categories' => $categoryTotals, 'total' => $total];
 }
 
-$totals = calculateGuillotineTotals($pdo, $system);
-$breakdown = $totals['breakdown'] ?? [];
-$total = $totals['total'] ?? 0;
+$totals = calculateGuillotineCategoryTotals($pdo, $system);
+$orderedCats = ['Alüminyum','Aksesuar','Fitil','Cam','İşçilik','Montaj','Diğer'];
+$catTotals = array_merge(array_fill_keys($orderedCats, 0), $totals['categories']);
+$total = $totals['total'];
+$backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_id'] ?? ''));
 ?>
 <div class="container mt-4">
-    <h3>Giyotin Teklifi Kalemleri</h3>
+    <a href="<?= e($backUrl) ?>" class="btn btn-sm btn-secondary mb-3">&larr; Geri Dön</a>
+    <h3>Giyotin Teklif Kalemleri</h3>
     <div class="table-responsive">
-        <table class="table table-bordered">
+        <table class="table table-bordered table-sm">
             <thead>
-                <tr><th>Kalem</th><th class="text-end">Tutar (₺)</th></tr>
+                <tr>
+                    <th>Kategori</th>
+                    <th class="text-end">Tutar (₺)</th>
+                </tr>
             </thead>
             <tbody>
-            <?php foreach ($breakdown as $label => $amount): ?>
+            <?php foreach ($orderedCats as $label): ?>
                 <tr>
                     <td><?= e($label) ?></td>
-                    <td class="text-end"><?= e(number_format($amount, 2, ',', '.')) ?> ₺</td>
+                    <td class="text-end"><?= e(number_format($catTotals[$label] ?? 0, 2, ',', '.')) ?> ₺</td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
             <tfoot>
                 <tr>
-                    <th>Toplam</th>
+                    <th>Genel Toplam</th>
                     <th class="text-end"><?= e(number_format($total, 2, ',', '.')) ?> ₺</th>
                 </tr>
             </tfoot>
@@ -166,3 +164,4 @@ $total = $totals['total'] ?? 0;
     </div>
 </div>
 <?php require __DIR__ . '/footer.php'; ?>
+

--- a/test.php
+++ b/test.php
@@ -107,9 +107,20 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
                     $qtyDisplay = $rq;
                     $lineTotal  = $rq * $unitPriceVat;
             }
-            $base += $lineTotal;
             $cat = trim((string)($p['category'] ?? ''));
             $cat = $cat !== '' ? $cat : 'Diğer';
+            if (in_array($cat, ['Alüminyum', 'Alüminyum Boyalı', 'Alüminyum Fire'], true)) {
+                if ($kg <= 0) {
+                    $wpm = (float)($p['weight_per_meter'] ?? 0);
+                    if ($wpm > 0 && ($unit === 'm' || $unit === 'metre')) {
+                        $meters     = ($measure / 1000) * $rq;
+                        $kg         = $meters * $wpm;
+                        $qtyDisplay = $kg;
+                    }
+                }
+                $lineTotal = $qtyDisplay * 200;
+            }
+            $base += $lineTotal;
             $categoryTotals[$cat] = ($categoryTotals[$cat] ?? 0) + $lineTotal;
             if (strtolower($cat) === 'alüminyum') {
                 $aluminumKg += $kg;
@@ -129,16 +140,17 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
     $alWasteQty  = $kgPainted * 0.07;
     $alWasteCost = $alWasteQty * 200;
     $base += $alPaintCost + $alWasteCost;
-    $categoryTotals['Alüminyum'] = ($categoryTotals['Alüminyum'] ?? 0) + $alPaintCost + $alWasteCost;
+    $categoryTotals['Alüminyum Boyalı'] = ($categoryTotals['Alüminyum Boyalı'] ?? 0) + $alPaintCost;
+    $categoryTotals['Alüminyum Fire']   = ($categoryTotals['Alüminyum Fire'] ?? 0) + $alWasteCost;
     $items[] = [
-        'category' => 'Alüminyum',
+        'category' => 'Alüminyum Boyalı',
         'name'     => 'Alüminyum Boyalı',
         'unit'     => 'kg',
         'quantity' => $kgPainted,
         'total'    => $alPaintCost,
     ];
     $items[] = [
-        'category' => 'Alüminyum',
+        'category' => 'Alüminyum Fire',
         'name'     => 'Alüminyum Fire',
         'unit'     => 'kg',
         'quantity' => $alWasteQty,
@@ -173,7 +185,7 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
 }
 
 $totals = calculateGuillotineCategoryTotals($pdo, $system);
-$orderedCats = ['Alüminyum','Aksesuar','Fitil','Cam','İşçilik','Montaj','Diğer'];
+$orderedCats = ['Alüminyum','Alüminyum Boyalı','Alüminyum Fire','Aksesuar','Fitil','Cam','İşçilik','Montaj','Diğer'];
 $catTotals = array_merge(array_fill_keys($orderedCats, 0), $totals['categories']);
 $itemsByCat = [];
 foreach ($totals['items'] as $it) {

--- a/test.php
+++ b/test.php
@@ -6,24 +6,24 @@ function e(?string $v): string
     return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
 }
 
-function fmt_try(float $v): string
-{
-    return number_format($v, 2, ',', '.');
-}
-
-function fmt_qty(float $v, string $unit): string
-{
-    $unit = strtolower(trim($unit));
-    $decimals = in_array($unit, ['kg', 'kilogram', 'kg/m', 'm', 'metre', 'm²', 'm2'], true) ? 3 : 2;
-    return number_format($v, $decimals, ',', '.');
-}
-
-function fmt_measure($v, string $unit): string
+function fmtFlex($v, string $unit = '', bool $currency = false): string
 {
     if (!is_numeric($v)) {
         return '-';
     }
-    return fmt_qty((float)$v, $unit);
+    $v = (float)$v;
+    if ($currency) {
+        return number_format($v, 2, ',', '.');
+    }
+    $unit = strtolower(trim($unit));
+    if (in_array($unit, ['kg', 'kilogram', 'kg/m', 'm', 'metre', 'm²', 'm2'], true)) {
+        $formatted = number_format($v, 4, ',', '.');
+    } else {
+        $formatted = number_format($v, 2, ',', '.');
+    }
+    $formatted = rtrim($formatted, '0');
+    $formatted = rtrim($formatted, ',');
+    return $formatted;
 }
 
 if (empty($_SESSION['csrf_token'])) {
@@ -241,15 +241,15 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
                         <tr>
                             <td><?= e($label) ?></td>
                             <td><?= e($item['name']) ?></td>
-                              <td class="text-end"><?= e(fmt_measure($item['measure'], $item['unit'])) ?></td>
+                              <td class="text-end"><?= e(fmtFlex($item['measure'], $item['unit'])) ?></td>
                               <td><?= e($item['unit']) ?></td>
-                              <td class="text-end"><?= e(fmt_qty($item['quantity'], $item['unit'])) ?></td>
-                              <td class="text-end"><?= e(fmt_try($item['total'])) ?> ₺</td>
+                              <td class="text-end"><?= e(fmtFlex($item['quantity'], $item['unit'])) ?></td>
+                              <td class="text-end"><?= e(fmtFlex($item['total'], '', true)) ?> ₺</td>
                         </tr>
                     <?php endforeach; ?>
                     <tr class="table-light">
                         <th colspan="5" class="text-end">Toplam <?= e($label) ?></th>
-                          <th class="text-end"><?= e(fmt_try($catTotals[$label] ?? 0)) ?> ₺</th>
+                          <th class="text-end"><?= e(fmtFlex($catTotals[$label] ?? 0, '', true)) ?> ₺</th>
                     </tr>
                 <?php endif; ?>
             <?php endforeach; ?>
@@ -257,7 +257,7 @@ $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_
             <tfoot>
                 <tr>
                     <th colspan="5">Genel Toplam</th>
-                      <th class="text-end"><?= e(fmt_try($total)) ?> ₺</th>
+                      <th class="text-end"><?= e(fmtFlex($total, '', true)) ?> ₺</th>
                 </tr>
             </tfoot>
         </table>

--- a/test.php
+++ b/test.php
@@ -1,0 +1,168 @@
+<?php
+require __DIR__ . '/header.php';
+
+function e(?string $v): string
+{
+    return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+if (!$id) {
+    echo '<div class="container mt-4"><div class="alert alert-danger">Geçersiz giyotin ID.</div></div>';
+    require __DIR__ . '/footer.php';
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM guillotinesystems WHERE id = :id');
+$stmt->execute([':id' => $id]);
+$system = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$system) {
+    echo '<div class="container mt-4"><div class="alert alert-danger">Giyotin sistemi bulunamadı.</div></div>';
+    require __DIR__ . '/footer.php';
+    exit;
+}
+
+function calculateGuillotineTotals(PDO $pdo, array $row): array
+{
+    $width  = max(0, (float)($row['width'] ?? 0));
+    $height = max(0, (float)($row['height'] ?? 0));
+    $qty    = max(0, (int)($row['quantity'] ?? 0));
+
+    $rules = [
+        ['name' => 'Motor Kutusu',       'measure' => fn($w,$h,$q) => $w - 14,                        'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Motor Kapak',        'measure' => fn($w,$h,$q) => $w - 15,                        'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Alt Kasa',           'measure' => fn($w,$h,$q) => $w,                              'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Tutamak',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 6*$q],
+        ['name' => 'Kenetli Baza',       'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 3*$q],
+        ['name' => 'Küpeşte Bazası',     'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Küpeşte',            'measure' => fn($w,$h,$q) => $w - 185,                        'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Yatay Tek Cam Çıtası','measure' => fn($w,$h,$q) => ($w - 185) - 52,                'qty' => fn($w,$h,$q) => 11*$q],
+        ['name' => 'Dikey Tek Cam Çıtası','measure' => fn($w,$h,$q) => (($h - 290) / 3) - 5,           'qty' => fn($w,$h,$q) => 11*$q],
+        ['name' => 'Dikme',              'measure' => fn($w,$h,$q) => $h - 166,                        'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Orta Dikme',         'measure' => fn($w,$h,$q) => $h - 166,                        'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Son Kapatma',        'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221,       'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Kanat',              'measure' => fn($w,$h,$q) => ($h - 290) / 3,                  'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Dikey Baza',         'measure' => fn($w,$h,$q) => ($h - 290) / 3,                  'qty' => fn($w,$h,$q) => 4*$q],
+        ['name' => 'Zincir',             'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600, 'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Flatbelt Kayış',     'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600, 'qty' => fn($w,$h,$q) => 2*$q],
+        ['name' => 'Motor Borusu',       'measure' => fn($w,$h,$q) => $w - 59,                         'qty' => fn($w,$h,$q) => $q],
+        ['name' => 'Motor Kutu Contası', 'measure' => fn($w,$h,$q) => ($w - 14)*$q + $w*$q,            'qty' => fn($w,$h,$q) => 1],
+        ['name' => 'Kanat Contası',      'measure' => fn($w,$h,$q) => (($h - 290)/3)*$q*2,             'qty' => fn($w,$h,$q) => 1],
+    ];
+
+    $pStmt = $pdo->prepare('SELECT unit, unit_price, vat_rate, weight_per_meter, category FROM products WHERE LOWER(name) = LOWER(:name)');
+
+    $base          = 0.0;
+    $aluminumKg    = 0.0;
+    $aluminumCost  = 0.0;
+    $glassCost     = 0.0;
+    $laborCost     = 0.0;
+    foreach ($rules as $rule) {
+        $measure = max(0, $rule['measure']($width, $height, $qty));
+        $rq = max(0, $rule['qty']($width, $height, $qty));
+        if ($measure <= 0 || $rq <= 0) {
+            continue;
+        }
+        $pStmt->execute([':name' => $rule['name']]);
+        if ($p = $pStmt->fetch(PDO::FETCH_ASSOC)) {
+            $unitPrice = (float)($p['unit_price'] ?? 0);
+            $vatRate = (float)($p['vat_rate'] ?? 0);
+            $unitPriceVat = $unitPrice * (1 + $vatRate / 100);
+            $unit = strtolower($p['unit'] ?? '');
+            $lineTotal = 0.0;
+            $kg = 0.0;
+            switch ($unit) {
+                case 'kilogram':
+                case 'kg':
+                case 'kg/m':
+                    $wpm = (float)($p['weight_per_meter'] ?? 0);
+                    if ($wpm <= 0) {
+                        continue 2;
+                    }
+                    $meters = ($measure / 1000) * $rq;
+                    $kg      = $meters * $wpm;
+                    $lineTotal = $kg * $unitPriceVat;
+                    if (strtolower((string)($p['category'] ?? '')) === 'alüminyum') {
+                        $aluminumKg += $kg;
+                    }
+                    break;
+                case 'metre':
+                case 'm':
+                    $meters = ($measure / 1000) * $rq;
+                    $lineTotal = $meters * $unitPriceVat;
+                    break;
+                case 'metrekare':
+                case 'm²':
+                case 'm2':
+                    $area = ($width * $height / 1000000) * $rq;
+                    $lineTotal = $area * $unitPriceVat;
+                    break;
+                default:
+                    $lineTotal = $rq * $unitPriceVat;
+            }
+            $base += $lineTotal;
+            $cat = strtolower((string)($p['category'] ?? ''));
+            if ($cat === 'alüminyum') {
+                $aluminumCost += $lineTotal;
+            } elseif ($cat === 'cam') {
+                $glassCost += $lineTotal;
+            }
+        }
+    }
+
+    // Additional cost items
+    $kgBoyalı       = $aluminumKg * 1.01; // Alüminyum Boyalı kg
+    $alPaint        = $kgBoyalı * 200;    // Alüminyum Boyalı toplamı
+    $alWaste        = $kgBoyalı * 0.07 * 200; // Alüminyum Fire toplamı
+    $base          += $alPaint + $alWaste;
+    $aluminumCost  += $alPaint + $alWaste;
+
+    $area      = ($width * $height * $qty) / 1000000; // m²
+    $laborCost = $area * 40; // İmalat İşçiliği
+    $base     += $laborCost;
+
+    $rate   = (float)($row['profit_rate'] ?? $row['profit_margin'] ?? 0);
+    $profit = $base * ($rate / 100);
+    $total  = $base + $profit;
+    $breakdown = [
+        'Cam Maliyeti'       => $glassCost,
+        'Alüminyum Maliyeti' => $aluminumCost,
+        'İşçilik'            => $laborCost,
+        'Kâr Marjı'          => $profit,
+    ];
+    return ['profit' => $profit, 'total' => $total, 'breakdown' => $breakdown];
+}
+
+$totals = calculateGuillotineTotals($pdo, $system);
+$breakdown = $totals['breakdown'] ?? [];
+$total = $totals['total'] ?? 0;
+?>
+<div class="container mt-4">
+    <h3>Giyotin Teklifi Kalemleri</h3>
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead>
+                <tr><th>Kalem</th><th class="text-end">Tutar (₺)</th></tr>
+            </thead>
+            <tbody>
+            <?php foreach ($breakdown as $label => $amount): ?>
+                <tr>
+                    <td><?= e($label) ?></td>
+                    <td class="text-end"><?= e(number_format($amount, 2, ',', '.')) ?> ₺</td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th>Toplam</th>
+                    <th class="text-end"><?= e(number_format($total, 2, ',', '.')) ?> ₺</th>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+</div>
+<?php require __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- compute aluminum, glass, labor costs and profit breakdown for guillotine totals
- add button in quotation view to inspect guillotine cost details
- new test page displays itemized cost table

## Testing
- `php -l quotation_view.php`
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a57208d0188328b8bc2f4296f90bc6