### PR TITLE
Adjust aluminium weight multipliers

### DIFF
--- a/test.php
+++ b/test.php
@@ -186,6 +186,10 @@ function calculateGuillotineCategoryTotals(PDO $pdo, array $row): array
                         $qtyDisplay = $kg;
                     }
                 }
+                if ($cat === 'Alüminyum') {
+                    $kg        *= 1.1;
+                    $qtyDisplay = $kg;
+                }
                 $lineTotal = $qtyDisplay * 200;
             }
             $base += $lineTotal;


### PR DESCRIPTION
## Summary
- apply 10% increase to raw aluminium weights
- keep painted and scrap calculations tied to updated aluminium totals

## Testing
- `php -l test.php`

------
https://chatgpt.com/codex/tasks/task_e_68a5c0d967548328a82348141d714041