### PR TITLE
Limit general total to selected categories

### DIFF
--- a/test.php
+++ b/test.php
@@ -279,7 +279,11 @@ $itemsByCat = [];
 foreach ($totals['items'] as $it) {
     $itemsByCat[$it['category']][] = $it;
 }
-$total = $totals['total'];
+$includedForTotal = ['Alüminyum Boyalı','Alüminyum Fire','Aksesuar','Fitil','İşçilik'];
+$total = 0;
+foreach ($includedForTotal as $c) {
+    $total += $catTotals[$c] ?? 0;
+}
 $backUrl = 'quotation_view.php?id=' . urlencode((string)($system['general_offer_id'] ?? ''));
 ?>
 <div class="container mt-4">


### PR DESCRIPTION
## Summary
- Recalculate grand total using only 'Alüminyum Boyalı', 'Alüminyum Fire', 'Aksesuar', 'Fitil', and 'İşçilik' categories

## Testing
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5c32d5ea48328b2cdf5c8fd011d19