### PR TITLE
Add dropdown lazy-load for guillotine items

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -373,6 +373,12 @@ $totalFormatted = tr_money($totalAmount) . ' ₺';
 $assemblyLabel = $assemblyTypes[$offer['assembly_type']] ?? 'Bilinmiyor';
 
 ?>
+<style>
+    .items-scroll { max-height: 320px; overflow: auto; }
+    .dropdown-menu .table-sm th,
+    .dropdown-menu .table-sm td { padding: .25rem .5rem; }
+    .dropdown-menu table { margin-bottom: 0; }
+</style>
 <nav aria-label="breadcrumb" class="mb-3">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="quotations.php">Teklifler</a></li>
@@ -476,36 +482,49 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                                     <td><?= e($g['ral_code']) ?></td>
                                     <td class="text-end"><?= e(number_format((float)$g['total_amount'], 2, ',', '.')) ?> ₺</td>
                                     <td class="text-end">
-                                        <a href="test.php?quote_id=<?= e((string)$g['id']) ?>" class="btn btn-sm btn-info">Kalemler</a>
-                                        <button type="button" class="btn btn-sm btn-secondary edit-guillotine" data-bs-toggle="modal" data-bs-target="#addGuillotineModal"
-                                            data-id="<?= e((string)$g['id']) ?>"
-                                            data-width="<?= e((string)$g['width']) ?>"
-                                            data-height="<?= e((string)$g['height']) ?>"
-                                            data-quantity="<?= e((string)$g['quantity']) ?>"
-                                            data-motor="<?= e($g['motor_system']) ?>"
-                                            data-glass-type="<?= e($g['glass_type']) ?>"
-                                            data-glass-color="<?= e($g['glass_color']) ?>"
-                                            data-remote="<?= e((string)$g['remote_quantity']) ?>"
-                                            data-ral="<?= e($g['ral_code']) ?>"
-                                            data-profit="<?= e((string)$g['profit_margin']) ?>">
-                                            Düzenle
-                                        </button>
-                                        <?php if ($role === 'admin' && strtolower((string)$g['system_type']) === 'guillotine'): ?>
-                                            <form method="post" class="d-inline" target="_blank">
-                                                <input type="hidden" name="action" value="optimize_guillotine">
-                                                <input type="hidden" name="guillotine_id" value="<?= e((string)$g['id']) ?>">
-                                                <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
-                                                <button type="submit" class="btn btn-sm btn-secondary"><i class="bi bi-gear"></i> Optimize</button>
-                                            </form>
-                                        <?php endif; ?>
-                                        <?php if ($role === 'admin'): ?>
-                                            <form method="post" class="d-inline" onsubmit="return confirm('Bu giyotin sistemini silmek istediğinize emin misiniz?');">
-                                                <input type="hidden" name="action" value="delete_guillotine">
-                                                <input type="hidden" name="guillotine_id" value="<?= e((string)$g['id']) ?>">
-                                                <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
-                                                <button type="submit" class="btn btn-sm btn-danger">Sil</button>
-                                            </form>
-                                        <?php endif; ?>
+                                        <div class="btn-group">
+                                            <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Hızlı Gör</button>
+                                            <div class="dropdown-menu dropdown-menu-end p-0">
+                                                <div class="d-flex justify-content-between align-items-center px-2 py-1 border-bottom">
+                                                    <span class="fw-bold small">Kalemler</span>
+                                                    <a href="test.php?quote_id=<?= e((string)$g['id']) ?>" class="small text-decoration-none">Detay »</a>
+                                                </div>
+                                                <div id="items-dd-<?= e((string)$g['id']) ?>" class="items-scroll" data-src="test.php?quote_id=<?= e((string)$g['id']) ?>&embed=1">
+                                                    <div class="p-2 text-center text-muted"><span class="spinner-border spinner-border-sm text-secondary me-2" role="status"></span>Yükleniyor…</div>
+                                                </div>
+                                                <div class="border-top p-2">
+                                                    <?php if ($role === 'admin' && strtolower((string)$g['system_type']) === 'guillotine'): ?>
+                                                        <form method="post" class="d-inline" target="_blank">
+                                                            <input type="hidden" name="action" value="optimize_guillotine">
+                                                            <input type="hidden" name="guillotine_id" value="<?= e((string)$g['id']) ?>">
+                                                            <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
+                                                            <button type="submit" class="btn btn-sm btn-secondary"><i class="bi bi-gear"></i> Optimize</button>
+                                                        </form>
+                                                    <?php endif; ?>
+                                                    <button type="button" class="btn btn-sm btn-secondary edit-guillotine" data-bs-toggle="modal" data-bs-target="#addGuillotineModal"
+                                                        data-id="<?= e((string)$g['id']) ?>"
+                                                        data-width="<?= e((string)$g['width']) ?>"
+                                                        data-height="<?= e((string)$g['height']) ?>"
+                                                        data-quantity="<?= e((string)$g['quantity']) ?>"
+                                                        data-motor="<?= e($g['motor_system']) ?>"
+                                                        data-glass-type="<?= e($g['glass_type']) ?>"
+                                                        data-glass-color="<?= e($g['glass_color']) ?>"
+                                                        data-remote="<?= e((string)$g['remote_quantity']) ?>"
+                                                        data-ral="<?= e($g['ral_code']) ?>"
+                                                        data-profit="<?= e((string)$g['profit_margin']) ?>">
+                                                        Düzenle
+                                                    </button>
+                                                    <?php if ($role === 'admin'): ?>
+                                                        <form method="post" class="d-inline" onsubmit="return confirm('Bu giyotin sistemini silmek istediğinize emin misiniz?');">
+                                                            <input type="hidden" name="action" value="delete_guillotine">
+                                                            <input type="hidden" name="guillotine_id" value="<?= e((string)$g['id']) ?>">
+                                                            <input type="hidden" name="csrf_token" value="<?= e($csrfToken) ?>">
+                                                            <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                                        </form>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>
@@ -656,6 +675,35 @@ document.getElementById('addGuillotineModal').addEventListener('show.bs.modal', 
         form.querySelector('#guillotine_id').value = '';
         this.querySelector('.modal-title').textContent = 'Add Guillotine System Offer';
     }
+});
+
+document.addEventListener('shown.bs.dropdown', (e) => {
+    const group = e.target.closest('.btn-group');
+    if (!group) {
+        return;
+    }
+    const container = group.querySelector('[id^="items-dd-"]');
+    if (!container || container.dataset.loaded === '1') {
+        return;
+    }
+    const src = container.getAttribute('data-src');
+    if (!src) {
+        return;
+    }
+    fetch(src, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+        .then(r => {
+            if (!r.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return r.text();
+        })
+        .then(html => {
+            container.innerHTML = html;
+            container.dataset.loaded = '1';
+        })
+        .catch(() => {
+            container.innerHTML = '<div class="p-2 text-danger small">Kalemler yüklenemedi.</div>';
+        });
 });
 
 </script>

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -482,9 +482,9 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                                     <td><?= e($g['ral_code']) ?></td>
                                     <td class="text-end"><?= e(number_format((float)$g['total_amount'], 2, ',', '.')) ?> ₺</td>
                                     <td class="text-end">
-                                        <div class="btn-group">
+                                        <div class="btn-group w-100 justify-content-end">
                                             <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Hızlı Gör</button>
-                                            <div class="dropdown-menu dropdown-menu-end p-0">
+                                            <div class="dropdown-menu dropdown-menu-end p-0 w-100">
                                                 <div class="d-flex justify-content-between align-items-center px-2 py-1 border-bottom">
                                                     <span class="fw-bold small">Kalemler</span>
                                                     <a href="test.php?quote_id=<?= e((string)$g['id']) ?>" class="small text-decoration-none">Detay »</a>

--- a/test.php
+++ b/test.php
@@ -232,7 +232,17 @@ function calculateGuillotineTotals(array $input): array
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $embed = ($_GET['embed'] ?? '') === '1';
-    if (!$embed) {
+    if ($embed) {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION['user_id'])) {
+            http_response_code(403);
+            echo '<div class="text-danger small">Oturum gerekli.</div>';
+            exit;
+        }
+        require __DIR__ . '/config.php';
+    } else {
         require __DIR__ . '/header.php';
     }
 

--- a/test.php
+++ b/test.php
@@ -231,7 +231,10 @@ function calculateGuillotineTotals(array $input): array
 }
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
-    require __DIR__ . '/header.php';
+    $embed = ($_GET['embed'] ?? '') === '1';
+    if (!$embed) {
+        require __DIR__ . '/header.php';
+    }
 
     function e(?string $v): string
     {
@@ -257,8 +260,10 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
 
     $id = filter_input(INPUT_GET, 'quote_id', FILTER_VALIDATE_INT);
     if (!$id) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Geçersiz giyotin.</div></div>';
-        require __DIR__ . '/footer.php';
+        echo $embed ? '<div class="text-danger small">Geçersiz giyotin.</div>' : '<div class="container mt-4"><div class="alert alert-danger">Geçersiz giyotin.</div></div>';
+        if (!$embed) {
+            require __DIR__ . '/footer.php';
+        }
         exit;
     }
 
@@ -266,8 +271,10 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $stmt->execute([':id' => $id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$row) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Giyotin satırı bulunamadı.</div></div>';
-        require __DIR__ . '/footer.php';
+        echo $embed ? '<div class="text-danger small">Giyotin satırı bulunamadı.</div>' : '<div class="container mt-4"><div class="alert alert-danger">Giyotin satırı bulunamadı.</div></div>';
+        if (!$embed) {
+            require __DIR__ . '/footer.php';
+        }
         exit;
     }
 
@@ -283,8 +290,32 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
             'provider'    => $provider,
         ]);
     } catch (Throwable $e) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Hesaplama hatası: ' . e($e->getMessage()) . '</div></div>';
-        require __DIR__ . '/footer.php';
+        $err = e($e->getMessage());
+        echo $embed ? '<div class="text-danger small">Hesaplama hatası: ' . $err . '</div>' : '<div class="container mt-4"><div class="alert alert-danger">Hesaplama hatası: ' . $err . '</div></div>';
+        if (!$embed) {
+            require __DIR__ . '/footer.php';
+        }
+        exit;
+    }
+
+    if ($embed) {
+        echo '<table class="table table-sm">';
+        echo '<thead><tr><th>Kalem</th><th>Ölçü/Adet</th><th>Birim</th><th>Birim Fiyat</th><th class="text-end">Tutar</th></tr></thead><tbody>';
+        foreach ($result['lines'] as $line) {
+            $measure = number_format($line['measure'], 2, ',', '.');
+            $qty = number_format($line['quantity'], 2, ',', '.');
+            $unitPrice = $line['quantity'] > 0 ? $line['total'] / $line['quantity'] : 0;
+            $unitPriceFmt = number_format($unitPrice, 2, ',', '.');
+            $totalFmt = number_format($line['total'], 2, ',', '.');
+            echo '<tr>';
+            echo '<td>' . e($line['name']) . '</td>';
+            echo '<td>' . e($measure) . ' / ' . e($qty) . '</td>';
+            echo '<td>' . e($line['unit']) . '</td>';
+            echo '<td>' . e($unitPriceFmt) . ' ₺</td>';
+            echo '<td class="text-end">' . e($totalFmt) . ' ₺</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
         exit;
     }
 
@@ -357,4 +388,3 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
 
     require __DIR__ . '/footer.php';
 }
-


### PR DESCRIPTION
## Summary
- add "Hızlı Gör" dropdown to guillotine rows with lazy-loaded item list
- include compact CSS and JS for lazy loading
- support `embed=1` on test.php to return minimal item table

## Testing
- `php -l quotation_view.php`
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6c39437dc8328854ea4a59f29e076