### PR TITLE
Compute general cost total from selected categories

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -15,6 +15,32 @@ if (!defined('BOOTSTRAP_LOADED')) {
         return number_format($v, 2, ',', '.');
     }
 
+    /**
+     * Calculate the general total using selected category totals and extras.
+     *
+     * Only "Alüminyum Boyalı", "Alüminyum Fire" and the provided extras are
+     * taken into account. Missing values are treated as zero.
+     *
+     * @param array $categoryTotals Associative array of category => amount
+     * @param array $extras         Associative array of extra costs
+     */
+    function calcGeneralTotal(array $categoryTotals = [], array $extras = []): float
+    {
+        $totals = [];
+        foreach ($categoryTotals as $k => $v) {
+            $totals[mb_strtolower($k, 'UTF-8')] = (float) $v;
+        }
+
+        $sum = ($totals['alüminyum boyalı'] ?? 0.0)
+              + ($totals['alüminyum fire'] ?? 0.0);
+
+        foreach ($extras as $v) {
+            $sum += (float) $v;
+        }
+
+        return $sum;
+    }
+
     set_error_handler(function ($severity, $message, $file, $line) {
         if (!(error_reporting() & $severity)) {
             return false;

--- a/test.php
+++ b/test.php
@@ -39,6 +39,7 @@ interface ProductProviderInterface
  *     profit: float,
  *     grand_total: float
  *   },
+ *   category_totals: array<string,float>,
  *   alu_kg: float
  * }
  */
@@ -113,6 +114,7 @@ function calculateGuillotineTotals(array $input): array
     $glassCost = 0.0;
     $baseCost = 0.0;
     $aluKg    = 0.0;
+    $categoryTotals = [];
 
     foreach ($rules as $rule) {
         $measure    = max(0.0, $rule['measure']($width, $height, $qty));
@@ -196,6 +198,9 @@ function calculateGuillotineTotals(array $input): array
             'quantity' => $qtyDisplay,
             'total'    => $lineTotal,
         ];
+
+        $catKey = mb_strtolower($category, 'UTF-8');
+        $categoryTotals[$catKey] = ($categoryTotals[$catKey] ?? 0) + $lineTotal;
     }
 
     $aluPaintedKg = $aluKg * 1.1 * 1.01;
@@ -209,8 +214,9 @@ function calculateGuillotineTotals(array $input): array
     $extras['labor'] = $area * 40;
 
     $baseCost += array_sum($extras);
-    $profit     = $baseCost * ($profitRate / 100);
-    $grandTotal = $baseCost + $profit;
+    $profit = $baseCost * ($profitRate / 100);
+
+    $grandTotal = calcGeneralTotal($categoryTotals, $extras);
 
     $totals = [
         'alu_cost'    => $aluCost,
@@ -224,6 +230,7 @@ function calculateGuillotineTotals(array $input): array
     return [
         'lines'          => $lines,
         'totals'         => $totals,
+        'category_totals'=> $categoryTotals,
         'alu_kg'         => $aluKg,
         'alu_painted_kg' => $aluPaintedKg,
         'alu_fire_kg'    => $aluFireKg,
@@ -381,7 +388,8 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     echo '</ul>';
     echo '<p><strong>Temel Maliyet:</strong> ' . e(number_format($tot['base_cost'], 2, ',', '.')) . ' ₺</p>';
     echo '<p><strong>Kâr:</strong> ' . e(number_format($tot['profit'], 2, ',', '.')) . ' ₺</p>';
-    echo '<p><strong>Genel Toplam:</strong> ' . e(number_format($tot['grand_total'], 2, ',', '.')) . ' ₺</p>';
+    echo '<h5>Genel Toplam</h5>';
+    echo '<p>' . e(number_format($tot['grand_total'], 2, ',', '.')) . ' ₺</p>';
     echo '</div></div>';
 
     require __DIR__ . '/footer.php';


### PR DESCRIPTION
## Summary
- add calcGeneralTotal() helper to sum painted aluminum, fire loss and extras
- track category totals in guillotine calculations and use new helper for grand total
- show formatted general total under heading

## Testing
- `php -l bootstrap.php`
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6e7acd6488328910cf0bccf1c19a2