### PR TITLE
Remove aluminum cost from grand total

### DIFF
--- a/test.php
+++ b/test.php
@@ -223,7 +223,9 @@ function calculateGuillotineTotals(array $input): array
     unset($otherExtras['paint'], $otherExtras['waste']);
     $otherExtrasCost = array_sum($otherExtras);
 
-    $grandTotal = ($aluCost + $paintCost)
+    // Grand total no longer includes the aluminum cost; it consists only of
+    // paint, fire, accessories, seal, glass and other extras costs.
+    $grandTotal = $paintCost
         + $fireCost
         + $aksesuarCost
         + $fitilCost


### PR DESCRIPTION
## Summary
- update grand total calculation to omit aluminum cost and rely on other cost components

## Testing
- `php -l test.php`
- `php -l pdf/templates/quotation.tpl.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6f8dcec14832896fd2bc1332e847d