### PR TITLE
Rename zincir accessory and sync pricing rules

### DIFF
--- a/guillotine_optimize_view.php
+++ b/guillotine_optimize_view.php
@@ -68,11 +68,12 @@ function computeSystem(array $row, PDO $pdo, array &$alerts): array {
         ['label' => 'Son Kapatma',           'name' => 'Son Kapatma',   'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221,                          'qty' => fn($w,$h,$q) => 2*$q],
         ['label' => 'Kanat',                 'name' => 'Kanat',         'measure' => fn($w,$h,$q) => ($h - 290) / 3,                                      'qty' => fn($w,$h,$q) => 2*$q],
         ['label' => 'Dikey Baza',            'name' => 'Dikey Baza',    'measure' => fn($w,$h,$q) => ($h - 290) / 3,                                      'qty' => fn($w,$h,$q) => 4*$q],
-        ['label' => 'Zincir',                'name' => 'Zincir',        'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600,                    'qty' => fn($w,$h,$q) => 2*$q],
         ['label' => 'Flatbelt Kayış',        'name' => 'Flatbelt Kayış',      'measure' => fn($w,$h,$q) => $h - (($h - 290)/3) - 221 + 600,                    'qty' => fn($w,$h,$q) => 2*$q],
         ['label' => 'Motor Borusu',          'name' => 'Motor Borusu',  'measure' => fn($w,$h,$q) => $w - 59,                                            'qty' => fn($w,$h,$q) => $q],
         ['label' => 'Motor Kutu Contası',    'name' => 'Motor Kutu Contası','measure' => fn($w,$h,$q) => ($w - 14)*$q + $w*$q,                                'qty' => fn($w,$h,$q) => 1],
         ['label' => 'Kanat Contası',         'name' => 'Kanat Contası',     'measure' => fn($w,$h,$q) => (($h - 290)/3)*$q*2,                                 'qty' => fn($w,$h,$q) => 1],
+        ['label' => 'Plastik Set',           'name' => 'Plastik Set',   'measure' => fn($w,$h,$q) => 1,                          'qty' => fn($w,$h,$q) => $q],
+        ['label' => 'Zincir',                'name' => 'Zincir',        'measure' => fn($w,$h,$q) => 1,                          'qty' => fn($w,$h,$q) => $q],
     ];
 
     $pStmt = $pdo->prepare('SELECT product_code, name, unit, unit_price, vat_rate, weight_per_meter FROM products WHERE LOWER(name) = LOWER(:name)');

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -41,10 +41,12 @@ $rules = [
     'Son Kapatma'          => fn($w, $h, $q) => [$h - (($h - 290) / 3) - 221, 2 * $q],
     'Kanat'                => fn($w, $h, $q) => [($h - 290) / 3, 2 * $q],
     'Dikey Baza'           => fn($w, $h, $q) => [($h - 290) / 3, 4 * $q],
-    'Zincir'               => fn($w, $h, $q) => [$h - (($h - 290) / 3) - 221 + 600, 2 * $q],
+    'Flatbelt Kayış'       => fn($w, $h, $q) => [$h - (($h - 290) / 3) - 221 + 600, 2 * $q],
     'Motor Borusu'         => fn($w, $h, $q) => [$w - 59, $q],
     'Motor Kutu Contası'   => fn($w, $h, $q) => [$w * $q * 2, 1],
     'Kanat Contası'        => fn($w, $h, $q) => [(($h - 290) / 3) * 2, $q],
+    'Plastik Set'          => fn($w, $h, $q) => [1, $q],
+    'Zincir'               => fn($w, $h, $q) => [1, $q],
     'Kıl Fitil'            => fn($w, $h, $q) => [(($w - 183) * 4) + (($h - 166) * 8) + ((($h - 290) / 3) * 2), $q],
 ];
 

--- a/pdf/render_optimization_pdf.php
+++ b/pdf/render_optimization_pdf.php
@@ -79,10 +79,12 @@ $rules = [
     'Son Kapatma'          => fn($w, $h, $q) => [$h - (($h - 290) / 3) - 221, 2 * $q],
     'Kanat'                => fn($w, $h, $q) => [($h - 290) / 3, 2 * $q],
     'Dikey Baza'           => fn($w, $h, $q) => [($h - 290) / 3, 4 * $q],
-    'Zincir'               => fn($w, $h, $q) => [$h - (($h - 290) / 3) - 221 + 600, 2 * $q],
+    'Flatbelt Kayış'       => fn($w, $h, $q) => [$h - (($h - 290) / 3) - 221 + 600, 2 * $q],
     'Motor Borusu'         => fn($w, $h, $q) => [$w - 59, $q],
     'Motor Kutu Contası'   => fn($w, $h, $q) => [$w * $q * 2, 1],
     'Kanat Contası'        => fn($w, $h, $q) => [(($h - 290) / 3) * 2, $q],
+    'Plastik Set'          => fn($w, $h, $q) => [1, $q],
+    'Zincir'               => fn($w, $h, $q) => [1, $q],
     'Kıl Fitil'            => fn($w, $h, $q) => [(($w - 183) * 4) + (($h - 166) * 8) + ((($h - 290) / 3) * 2), $q],
 ];
 

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -26,7 +26,7 @@ SET time_zone = "+00:00";
 --
 -- Tablo için tablo yapısı `categories`
 --
-
+DROP TABLE IF EXISTS `categories`;
 CREATE TABLE `categories` (
   `id` int(11) NOT NULL,
   `name` varchar(255) NOT NULL,
@@ -207,11 +207,12 @@ INSERT INTO `products` (`id`, `product_code`, `name`, `category`, `unit`, `chann
 (12, 'ALU-012', 'Son Kapatma', 'Alüminyum', 'kg/m', NULL, NULL, NULL, NULL, 'uploads/prod_689d8e53630e23.99446192.png', NULL, 200.00, 0.980, 20.00, 1),
 (13, 'ALU-013', 'Kanat', 'Alüminyum', 'kg/m', NULL, NULL, NULL, NULL, 'uploads/prod_689d979f9d9095.83107493.png', NULL, 200.00, 1.499, 20.00, 1),
 (14, 'ALU-014', 'Dikey Baza', 'Alüminyum', 'kg/m', NULL, NULL, NULL, NULL, 'uploads/prod_689d98fb17a318.00944727.png', NULL, 200.00, 0.627, 20.00, 1),
-(15, 'AKS-001', 'Zincir', 'Aksesuar', 'adet', NULL, NULL, NULL, NULL, 'uploads/prod_689daf670db319.58780229.png', NULL, 900.00, 1.000, 20.00, 2),
+(15, 'AKS-001', 'Plastik Set', 'Aksesuar', 'set', NULL, NULL, NULL, NULL, 'uploads/prod_689daf670db319.58780229.png', NULL, 1680.00, 1.000, 20.00, 2),
 (17, 'ALU-015', 'Motor Borusu', 'Aksesuar', 'adet', NULL, NULL, NULL, NULL, 'uploads/prod_689dba8ccbd6a4.05135182.png', NULL, 190.00, 1.000, 20.00, 1),
 (18, 'FIT-001', 'Motor Kutu Contası', 'Fitil', 'm', NULL, NULL, NULL, NULL, 'uploads/prod_689dbaa5c1c036.57568229.png', NULL, 30.00, 1.000, 20.00, 3),
 (19, 'FIT-002', 'Kanat Contası', 'Fitil', 'm', NULL, NULL, NULL, NULL, 'uploads/prod_689dbabf730f57.59776694.png', NULL, 30.00, 1.000, 20.00, 3),
-(20, 'PRD-01', 'Kıl Fitil', 'Fitil', 'm', NULL, NULL, NULL, NULL, 'uploads/prod_689dbad192dca3.02797000.jpg', NULL, 25.00, 1.000, 20.00, NULL);
+(20, 'PRD-01', 'Kıl Fitil', 'Fitil', 'm', NULL, NULL, NULL, NULL, 'uploads/prod_689dbad192dca3.02797000.jpg', NULL, 25.00, 1.000, 20.00, NULL),
+(21, 'AKS-021', 'Zincir', 'Aksesuar', 'set', NULL, NULL, NULL, NULL, NULL, NULL, 680.00, 1.000, 20.00, 2);
 
 -- --------------------------------------------------------
 

--- a/test.php
+++ b/test.php
@@ -90,11 +90,11 @@ function calculateGuillotineTotals(array $input): array
         ['name' => 'Son Kapatma',        'measure' => fn($w,$h,$q) => $h - (($h - 290) / 3) - 221,      'qty' => fn($w,$h,$q) => 2 * $q],
         ['name' => 'Kanat',              'measure' => fn($w,$h,$q) => ($h - 290) / 3,                   'qty' => fn($w,$h,$q) => 2 * $q],
         ['name' => 'Dikey Baza',         'measure' => fn($w,$h,$q) => ($h - 290) / 3,                   'qty' => fn($w,$h,$q) => 4 * $q],
-        ['name' => 'Plastik Set',        'measure' => fn($w,$h,$q) => 1,                                'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Flatbelt Kayış',     'measure' => fn($w,$h,$q) => $h - (($h - 290) / 3) - 221 + 600,'qty' => fn($w,$h,$q) => 2 * $q],
         ['name' => 'Motor Borusu',       'measure' => fn($w,$h,$q) => $w - 75,                          'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Motor Kutu Contası', 'measure' => fn($w,$h,$q) => ($w - 14) * $q + $w * $q,         'qty' => fn($w,$h,$q) => 1],
         ['name' => 'Kanat Contası',      'measure' => fn($w,$h,$q) => (($h - 290) / 3) * $q * 2,        'qty' => fn($w,$h,$q) => 1],
+        ['name' => 'Plastik Set',        'measure' => fn($w,$h,$q) => 1,                                'qty' => fn($w,$h,$q) => $q],
         ['name' => 'Zincir',             'measure' => fn($w,$h,$q) => 1,                                'qty' => fn($w,$h,$q) => $q],
     ]);
 


### PR DESCRIPTION
## Summary
- rename existing "Zincir" accessory to "Plastik Set" with set unit and add a new "Zincir" set product
- synchronize product names across calculation, optimization view, and PDF export
- update database seed with Plastik Set and new Zincir prices
- drop existing categories table before recreation in SQL dump to prevent import errors

## Testing
- `php -l test.php`
- `php -l optimizasyon.php`
- `php -l pdf/render_optimization_pdf.php`
- `php -l guillotine_optimize_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7008e2fa483288c3c6da7cb507741