### PR TITLE
Compute aluminum waste cost per kilogram

### DIFF
--- a/test.php
+++ b/test.php
@@ -208,9 +208,10 @@ function calculateGuillotineTotals(array $input): array
     $aluFireKg    = $aluPaintedKg * 0.07;
 
     $extras = [
-        'paint' => $aluPaintedKg * 200,
+        'paint'  => $aluPaintedKg * 200,
+        // Fire cost calculated per kilogram of aluminum waste
+        'waste'  => $aluFireKg * 200,
     ];
-    $extras['waste'] = ($aluCost + $extras['paint']) * 0.07;
     $area = ($width * $height * $qty) / 1000000; // m²
     $extras['labor'] = $area * 40;
 


### PR DESCRIPTION
## Summary
- Calculate aluminum waste using weight-based cost: waste kilograms multiplied by 200₺.

## Testing
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a713f490ec83288f3f1d2d74d7de73