### PR TITLE
Add PDF export for quotation view

### DIFF
--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -33,6 +33,8 @@ if (!$id) {
     exit('Missing or invalid quotation id.');
 }
 
+$guillotines = [];
+$slidings    = [];
 try {
     // Quote master
     $stmt = $pdo->prepare("
@@ -81,6 +83,15 @@ try {
         }
     }
 
+    // Fetch guillotine and sliding systems
+    $gStmt = $pdo->prepare('SELECT system_type, width, height, quantity, motor_system, ral_code, glass_type, glass_color, total_amount FROM guillotinesystems WHERE general_offer_id = :id');
+    $gStmt->execute([':id' => $id]);
+    $guillotines = $gStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $sStmt = $pdo->prepare('SELECT system_type, width, height, quantity, wing_type, ral_code, glass_type, glass_color, total_amount FROM slidingsystems WHERE general_offer_id = :id');
+    $sStmt->execute([':id' => $id]);
+    $slidings = $sStmt->fetchAll(PDO::FETCH_ASSOC);
+
     // Company profile (logo/name) if available
     $company = ['name' => '', 'email' => '', 'phone' => '', 'logo' => null, 'address' => ''];
     try {
@@ -116,7 +127,7 @@ $canUseMpdf = class_exists('\\Mpdf\\Mpdf');
 
 if ($canUseMpdf) {
     // Build HTML via template if exists, else inline template
-    $html = (function() use ($quote, $items, $company, $assemblyText, $paymentText, $validityText) {
+    $html = (function() use ($quote, $guillotines, $slidings, $company, $assemblyText, $paymentText, $validityText) {
         $tpl = __DIR__ . '/templates/quotation.tpl.php';
         if (is_file($tpl)) {
             // The template should read $quote, $items, $company, etc.
@@ -126,24 +137,45 @@ if ($canUseMpdf) {
         } else {
             // Minimal inline HTML
             $customerFull = trim(($quote['first_name'] ?? '') . ' ' . ($quote['last_name'] ?? ''));
-            $dateStr = $quote['created_at'] ?? date('Y-m-d');
+            $dateStr = $quote['offer_date'] ?? ($quote['created_at'] ?? date('Y-m-d'));
             $title = 'Teklif #' . (int)$quote['id'];
-            $rows = '';
-            $total = 0.0;
-            foreach ($items as $i => $it) {
-                $qty = (float)($it['quantity'] ?? $it['qty'] ?? 0);
-                $price = (float)($it['unit_price'] ?? $it['price'] ?? 0);
-                $line = $qty * $price;
-                $total += $line;
-                $rows .= '<tr>
-                    <td>'.($i+1).'</td>
-                    <td>'.h($it['product_code'] ?? '').'</td>
-                    <td>'.h($it['product_name'] ?? $it['name'] ?? '').'</td>
-                    <td style="text-align:right">'.number_format($qty, 2, ',', '.').'</td>
-                    <td style="text-align:right">'.number_format($price, 2, ',', '.').'</td>
-                    <td style="text-align:right">'.number_format($line, 2, ',', '.').'</td>
+
+            $gRows = '';
+            $gTotal = 0.0;
+            foreach ($guillotines as $g) {
+                $line = (float)($g['total_amount'] ?? 0);
+                $gTotal += $line;
+                $gRows .= '<tr>
+                    <td>'.h($g['system_type'] ?? '').'</td>
+                    <td>'.h($g['width'] ?? '').'</td>
+                    <td>'.h($g['height'] ?? '').'</td>
+                    <td>'.h($g['quantity'] ?? '').'</td>
+                    <td>'.h(trim(($g['glass_type'] ?? '').' '.($g['glass_color'] ?? ''))).'</td>
+                    <td>'.h($g['motor_system'] ?? '').'</td>
+                    <td>'.h($g['ral_code'] ?? '').'</td>
+                    <td style="text-align:right">'.number_format($line,2,',','.').'</td>
                 </tr>';
             }
+
+            $sRows = '';
+            $sTotal = 0.0;
+            foreach ($slidings as $s) {
+                $line = (float)($s['total_amount'] ?? 0);
+                $sTotal += $line;
+                $sRows .= '<tr>
+                    <td>'.h($s['system_type'] ?? '').'</td>
+                    <td>'.h($s['width'] ?? '').'</td>
+                    <td>'.h($s['height'] ?? '').'</td>
+                    <td>'.h($s['quantity'] ?? '').'</td>
+                    <td>'.h(trim(($s['glass_type'] ?? '').' '.($s['glass_color'] ?? ''))).'</td>
+                    <td>'.h($s['wing_type'] ?? '').'</td>
+                    <td>'.h($s['ral_code'] ?? '').'</td>
+                    <td style="text-align:right">'.number_format($line,2,',','.').'</td>
+                </tr>';
+            }
+
+            $grand = $gTotal + $sTotal;
+
             return '
 <!DOCTYPE html>
 <html lang="tr">
@@ -152,7 +184,7 @@ if ($canUseMpdf) {
 <style>
 body { font-family: DejaVu Sans, Arial, sans-serif; font-size: 11pt; }
 h1 { font-size: 16pt; margin: 0 0 8pt; }
-.table { width:100%; border-collapse: collapse; }
+.table { width:100%; border-collapse: collapse; margin-bottom: 10px; }
 .table th, .table td { border:1px solid #888; padding:6px; }
 .text-right { text-align:right; }
 .small { font-size: 9pt; color:#333; }
@@ -165,24 +197,12 @@ h1 { font-size: 16pt; margin: 0 0 8pt; }
   '.($assemblyText ? '<div class="small">Montaj: '.h($assemblyText).'</div>' : '').'
   '.($paymentText ? '<div class="small">Ödeme: '.h($paymentText).'</div>' : '').'
   '.($validityText ? '<div class="small">Geçerlilik: '.h($validityText).'</div>' : '').'
-
   <br>
-  <table class="table">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Kod</th>
-        <th>Ürün</th>
-        <th class="text-right">Adet</th>
-        <th class="text-right">Birim Fiyat</th>
-        <th class="text-right">Tutar</th>
-      </tr>
-    </thead>
-    <tbody>
-      '.$rows.'
-    </tbody>
-  </table>
-  <p class="text-right"><strong>Genel Toplam: ' . number_format($total, 2, ',', '.') . ' </strong></p>
+  <h3>Giyotin Sistemleri</h3>
+  '.($gRows ? '<table class="table"><thead><tr><th>Sistem</th><th>En</th><th>Boy</th><th>Adet</th><th>Cam</th><th>Motor</th><th>RAL</th><th class="text-right">Toplam</th></tr></thead><tbody>'.$gRows.'</tbody></table>' : '<p>Giyotin sistemi bulunamadı.</p>').'
+  <h3>Sürme Sistemleri</h3>
+  '.($sRows ? '<table class="table"><thead><tr><th>Sistem</th><th>En</th><th>Boy</th><th>Adet</th><th>Cam</th><th>Kanat</th><th>RAL</th><th class="text-right">Toplam</th></tr></thead><tbody>'.$sRows.'</tbody></table>' : '<p>Sürme sistemi bulunamadı.</p>').'
+  <p class="text-right"><strong>Genel Toplam: '.number_format($grand,2,',','.').' </strong></p>
 </body>
 </html>';
         }
@@ -215,36 +235,73 @@ if (!empty($paymentText))  { $pdf->Cell(0, 6, enc('Ödeme: ' . $paymentText), 0,
 if (!empty($validityText)) { $pdf->Cell(0, 6, enc('Geçerlilik: ' . $validityText), 0, 1); }
 $pdf->Ln(2);
 
-// Table header
-$pdf->SetFont('Arial', 'B', 10);
-$pdf->Cell(10, 8, '#', 1, 0, 'C');
-$pdf->Cell(30, 8, enc('Kod'), 1, 0);
-$pdf->Cell(80, 8, enc('Ürün'), 1, 0);
-$pdf->Cell(20, 8, enc('Adet'), 1, 0, 'R');
-$pdf->Cell(25, 8, enc('Birim'), 1, 0, 'R');
-$pdf->Cell(25, 8, enc('Tutar'), 1, 1, 'R');
-
-$pdf->SetFont('Arial', '', 10);
 $total = 0.0;
-$index = 1;
-foreach ($items as $it) {
-    $qty   = (float)($it['quantity'] ?? $it['qty'] ?? 0);
-    $price = (float)($it['unit_price'] ?? $it['price'] ?? 0);
-    $line  = $qty * $price;
-    $total += $line;
 
-    $pdf->Cell(10, 7, (string)$index, 1, 0, 'C');
-    $pdf->Cell(30, 7, enc((string)($it['product_code'] ?? '')), 1, 0);
-    $pdf->Cell(80, 7, enc((string)($it['product_name'] ?? $it['name'] ?? '')), 1, 0);
-    $pdf->Cell(20, 7, number_format($qty, 2, ',', '.'), 1, 0, 'R');
-    $pdf->Cell(25, 7, number_format($price, 2, ',', '.'), 1, 0, 'R');
-    $pdf->Cell(25, 7, number_format($line, 2, ',', '.'), 1, 1, 'R');
-    $index++;
+// Guillotine table
+$pdf->SetFont('Arial', 'B', 10);
+$pdf->Cell(0, 6, enc('Giyotin Sistemleri'), 0, 1);
+if ($guillotines) {
+    $pdf->SetFont('Arial', 'B', 9);
+    $pdf->Cell(25, 7, enc('Sistem'), 1, 0);
+    $pdf->Cell(20, 7, enc('En'), 1, 0, 'R');
+    $pdf->Cell(20, 7, enc('Boy'), 1, 0, 'R');
+    $pdf->Cell(15, 7, enc('Adet'), 1, 0, 'R');
+    $pdf->Cell(30, 7, enc('Cam'), 1, 0);
+    $pdf->Cell(25, 7, enc('Motor'), 1, 0);
+    $pdf->Cell(20, 7, enc('RAL'), 1, 0);
+    $pdf->Cell(35, 7, enc('Toplam'), 1, 1, 'R');
+    $pdf->SetFont('Arial', '', 9);
+    foreach ($guillotines as $g) {
+        $line = (float)($g['total_amount'] ?? 0);
+        $total += $line;
+        $pdf->Cell(25, 6, enc((string)($g['system_type'] ?? '')), 1, 0);
+        $pdf->Cell(20, 6, enc((string)($g['width'] ?? '')), 1, 0, 'R');
+        $pdf->Cell(20, 6, enc((string)($g['height'] ?? '')), 1, 0, 'R');
+        $pdf->Cell(15, 6, enc((string)($g['quantity'] ?? '')), 1, 0, 'R');
+        $pdf->Cell(30, 6, enc(trim(($g['glass_type'] ?? '') . ' ' . ($g['glass_color'] ?? ''))), 1, 0);
+        $pdf->Cell(25, 6, enc((string)($g['motor_system'] ?? '')), 1, 0);
+        $pdf->Cell(20, 6, enc((string)($g['ral_code'] ?? '')), 1, 0);
+        $pdf->Cell(35, 6, number_format($line, 2, ',', '.'), 1, 1, 'R');
+    }
+} else {
+    $pdf->SetFont('Arial', '', 9);
+    $pdf->Cell(0, 6, enc('Giyotin sistemi bulunamadı.'), 1, 1);
 }
+$pdf->Ln(4);
 
-// Total
+// Sliding table
+$pdf->SetFont('Arial', 'B', 10);
+$pdf->Cell(0, 6, enc('Sürme Sistemleri'), 0, 1);
+if ($slidings) {
+    $pdf->SetFont('Arial', 'B', 9);
+    $pdf->Cell(25, 7, enc('Sistem'), 1, 0);
+    $pdf->Cell(20, 7, enc('En'), 1, 0, 'R');
+    $pdf->Cell(20, 7, enc('Boy'), 1, 0, 'R');
+    $pdf->Cell(15, 7, enc('Adet'), 1, 0, 'R');
+    $pdf->Cell(30, 7, enc('Cam'), 1, 0);
+    $pdf->Cell(25, 7, enc('Kanat'), 1, 0);
+    $pdf->Cell(20, 7, enc('RAL'), 1, 0);
+    $pdf->Cell(35, 7, enc('Toplam'), 1, 1, 'R');
+    $pdf->SetFont('Arial', '', 9);
+    foreach ($slidings as $s) {
+        $line = (float)($s['total_amount'] ?? 0);
+        $total += $line;
+        $pdf->Cell(25, 6, enc((string)($s['system_type'] ?? '')), 1, 0);
+        $pdf->Cell(20, 6, enc((string)($s['width'] ?? '')), 1, 0, 'R');
+        $pdf->Cell(20, 6, enc((string)($s['height'] ?? '')), 1, 0, 'R');
+        $pdf->Cell(15, 6, enc((string)($s['quantity'] ?? '')), 1, 0, 'R');
+        $pdf->Cell(30, 6, enc(trim(($s['glass_type'] ?? '') . ' ' . ($s['glass_color'] ?? ''))), 1, 0);
+        $pdf->Cell(25, 6, enc((string)($s['wing_type'] ?? '')), 1, 0);
+        $pdf->Cell(20, 6, enc((string)($s['ral_code'] ?? '')), 1, 0);
+        $pdf->Cell(35, 6, number_format($line, 2, ',', '.'), 1, 1, 'R');
+    }
+} else {
+    $pdf->SetFont('Arial', '', 9);
+    $pdf->Cell(0, 6, enc('Sürme sistemi bulunamadı.'), 1, 1);
+}
+$pdf->Ln(4);
+
 $pdf->SetFont('Arial', 'B', 11);
-$pdf->Cell(165, 8, enc('Genel Toplam'), 1, 0, 'R');
-$pdf->Cell(25, 8, number_format($total, 2, ',', '.'), 1, 1, 'R');
+$pdf->Cell(0, 8, enc('Genel Toplam: ' . number_format($total, 2, ',', '.')), 0, 1, 'R');
 
 $pdf->Output('I', 'teklif.pdf');

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -444,7 +444,7 @@ $assemblyLabel = $assemblyTypes[$offer['assembly_type']] ?? 'Bilinmiyor';
 </nav>
 <?php
 $actions = '<a href="quotation_edit.php?id=' . e((string)$offer['id']) . '" class="btn btn-primary" data-bs-toggle="tooltip" title="Düzenle"><i class="bi bi-pencil"></i></a>';
-$actions .= ' <a href="pdf/render_quotation_pdf.php?id=' . e((string)$offer['id']) . '" class="btn btn-secondary btn-icon"><i class="bi bi-file-earmark-pdf"></i>PDF İndir</a>';
+$actions .= ' <a href="pdf/render_quotation_pdf.php?id=' . e((string)$offer['id']) . '" class="btn btn-secondary btn-icon" target="_blank"><i class="bi bi-file-earmark-pdf"></i>PDF İndir</a>';
 page_header('Teklif #' . e((string)$offer['id']), $actions);
 ?>
 <?php if ($success): ?><div class="alert alert-success"><?= e($success) ?></div><?php endif; ?>


### PR DESCRIPTION
## Summary
- Open PDF export from quotation details in a new tab
- Include summary, guillotine and sliding system offers in quotation PDF

## Testing
- `php -l quotation_view.php`
- `php -l pdf/render_quotation_pdf.php`


------
https://chatgpt.com/codex/tasks/task_e_68a80ba9d6348328824c3aa3ba2cfbf3