### PR TITLE
Ensure Turkish characters render in quotation PDFs

### DIFF
--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -237,7 +237,8 @@ require __DIR__ . '/../libs/fpdf.php';
 
 $pdf = new FPDF();
 $fontFile = __DIR__ . '/Roboto/Roboto-Regular.php';
-if (is_file($fontFile)) {
+$fontMissing = !is_file($fontFile);
+if (!$fontMissing) {
     $pdf->AddFont('Roboto', '', 'Roboto-Regular.php');
     $fontName = 'Roboto';
 } else {
@@ -246,6 +247,17 @@ if (is_file($fontFile)) {
 $pdf->SetTitle(enc('TEKLİF #' . (string)$quote['id']));
 $pdf->SetAutoPageBreak(true, 15);
 $pdf->AddPage();
+
+if ($fontMissing) {
+    // Bootstrap-like warning informing the user that Roboto is missing
+    $pdf->SetFillColor(255, 243, 205); // bg-warning
+    $pdf->SetDrawColor(255, 238, 186); // border-warning
+    $pdf->SetTextColor(133, 100, 4);   // text-warning
+    $pdf->SetFont('Arial', '', 10);
+    $pdf->MultiCell(0, 8, enc('Roboto fontu bulunamadı. Arial fontu kullanıldı.'), 1, 'L', true);
+    $pdf->Ln(4);
+    $pdf->SetTextColor(0, 0, 0); // reset text color
+}
 
 // Header
 $pdf->SetFont($fontName, 'B', 14);

--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -218,9 +218,6 @@ h1 { font-size: 16pt; margin: 0 0 8pt; }
 define('FPDF_FONTPATH', __DIR__ . '/Roboto/');
 require __DIR__ . '/../libs/fpdf.php';
 
-header('Content-Type: application/pdf');
-header('Content-Disposition: inline; filename="teklif.pdf"');
-
 $pdf = new FPDF();
 $fontFile = __DIR__ . '/Roboto/Roboto-Regular.php';
 if (is_file($fontFile)) {
@@ -230,8 +227,8 @@ if (is_file($fontFile)) {
     $fontName = 'Arial';
 }
 $pdf->SetTitle(enc('TEKLİF #' . (string)$quote['id']));
-$pdf->AddPage();
 $pdf->SetAutoPageBreak(true, 15);
+$pdf->AddPage();
 
 // Header
 $pdf->SetFont($fontName, 'B', 14);
@@ -314,6 +311,9 @@ $pdf->SetFont($fontName, 'B', 11);
 $pdf->Cell(0, 8, enc('Genel Toplam: ' . number_format($total, 2, ',', '.')), 0, 1, 'R');
 
 try {
+    if (ob_get_length()) {
+        ob_end_clean();
+    }
     $pdf->Output('I', 'teklif.pdf');
 } catch (Throwable $e) {
     error_log('PDF Output error: ' . $e->getMessage());

--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -208,10 +208,18 @@ h1 { font-size: 16pt; margin: 0 0 8pt; }
         }
     })();
 
-    $mpdf = new \Mpdf\Mpdf(['tempDir' => __DIR__ . '/../storage/tmp']);
-    $mpdf->WriteHTML($html);
-    $mpdf->Output('teklif.pdf', \Mpdf\Output\Destination::INLINE);
-    exit;
+    try {
+        $mpdfTemp = __DIR__ . '/../storage/mpdf_tmp';
+        if (!is_dir($mpdfTemp)) {
+            mkdir($mpdfTemp, 0777, true);
+        }
+        $mpdf = new \Mpdf\Mpdf(['tempDir' => $mpdfTemp]);
+        $mpdf->WriteHTML($html);
+        $mpdf->Output('teklif.pdf', \Mpdf\Output\Destination::INLINE);
+        exit;
+    } catch (Throwable $e) {
+        error_log('mPDF render error: ' . $e->getMessage());
+    }
 }
 
 // ---- FPDF fallback ----

--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -215,19 +215,28 @@ h1 { font-size: 16pt; margin: 0 0 8pt; }
 }
 
 // ---- FPDF fallback ----
+define('FPDF_FONTPATH', __DIR__ . '/Roboto/');
 require __DIR__ . '/../libs/fpdf.php';
 
 header('Content-Type: application/pdf');
-header('Content-Disposition: inline; filename=\"teklif.pdf\"');
+header('Content-Disposition: inline; filename="teklif.pdf"');
 
 $pdf = new FPDF();
+$fontFile = __DIR__ . '/Roboto/Roboto-Regular.php';
+if (is_file($fontFile)) {
+    $pdf->AddFont('Roboto', '', 'Roboto-Regular.php');
+    $fontName = 'Roboto';
+} else {
+    $fontName = 'Arial';
+}
+$pdf->SetTitle(enc('TEKLİF #' . (string)$quote['id']));
 $pdf->AddPage();
 $pdf->SetAutoPageBreak(true, 15);
 
 // Header
-$pdf->SetFont('Arial', 'B', 14);
+$pdf->SetFont($fontName, 'B', 14);
 $pdf->Cell(0, 8, enc('TEKLİF #' . (string)$quote['id']), 0, 1);
-$pdf->SetFont('Arial', '', 11);
+$pdf->SetFont($fontName, '', 11);
 $customerFull = trim(($quote['first_name'] ?? '') . ' ' . ($quote['last_name'] ?? ''));
 $pdf->Cell(0, 6, enc('Müşteri: ' . $customerFull), 0, 1);
 if (!empty($assemblyText)) { $pdf->Cell(0, 6, enc('Montaj: ' . $assemblyText), 0, 1); }
@@ -238,10 +247,10 @@ $pdf->Ln(2);
 $total = 0.0;
 
 // Guillotine table
-$pdf->SetFont('Arial', 'B', 10);
+$pdf->SetFont($fontName, 'B', 10);
 $pdf->Cell(0, 6, enc('Giyotin Sistemleri'), 0, 1);
 if ($guillotines) {
-    $pdf->SetFont('Arial', 'B', 9);
+    $pdf->SetFont($fontName, 'B', 9);
     $pdf->Cell(25, 7, enc('Sistem'), 1, 0);
     $pdf->Cell(20, 7, enc('En'), 1, 0, 'R');
     $pdf->Cell(20, 7, enc('Boy'), 1, 0, 'R');
@@ -250,7 +259,7 @@ if ($guillotines) {
     $pdf->Cell(25, 7, enc('Motor'), 1, 0);
     $pdf->Cell(20, 7, enc('RAL'), 1, 0);
     $pdf->Cell(35, 7, enc('Toplam'), 1, 1, 'R');
-    $pdf->SetFont('Arial', '', 9);
+    $pdf->SetFont($fontName, '', 9);
     foreach ($guillotines as $g) {
         $line = (float)($g['total_amount'] ?? 0);
         $total += $line;
@@ -264,16 +273,16 @@ if ($guillotines) {
         $pdf->Cell(35, 6, number_format($line, 2, ',', '.'), 1, 1, 'R');
     }
 } else {
-    $pdf->SetFont('Arial', '', 9);
+    $pdf->SetFont($fontName, '', 9);
     $pdf->Cell(0, 6, enc('Giyotin sistemi bulunamadı.'), 1, 1);
 }
 $pdf->Ln(4);
 
 // Sliding table
-$pdf->SetFont('Arial', 'B', 10);
+$pdf->SetFont($fontName, 'B', 10);
 $pdf->Cell(0, 6, enc('Sürme Sistemleri'), 0, 1);
 if ($slidings) {
-    $pdf->SetFont('Arial', 'B', 9);
+    $pdf->SetFont($fontName, 'B', 9);
     $pdf->Cell(25, 7, enc('Sistem'), 1, 0);
     $pdf->Cell(20, 7, enc('En'), 1, 0, 'R');
     $pdf->Cell(20, 7, enc('Boy'), 1, 0, 'R');
@@ -282,7 +291,7 @@ if ($slidings) {
     $pdf->Cell(25, 7, enc('Kanat'), 1, 0);
     $pdf->Cell(20, 7, enc('RAL'), 1, 0);
     $pdf->Cell(35, 7, enc('Toplam'), 1, 1, 'R');
-    $pdf->SetFont('Arial', '', 9);
+    $pdf->SetFont($fontName, '', 9);
     foreach ($slidings as $s) {
         $line = (float)($s['total_amount'] ?? 0);
         $total += $line;
@@ -296,12 +305,18 @@ if ($slidings) {
         $pdf->Cell(35, 6, number_format($line, 2, ',', '.'), 1, 1, 'R');
     }
 } else {
-    $pdf->SetFont('Arial', '', 9);
+    $pdf->SetFont($fontName, '', 9);
     $pdf->Cell(0, 6, enc('Sürme sistemi bulunamadı.'), 1, 1);
 }
 $pdf->Ln(4);
 
-$pdf->SetFont('Arial', 'B', 11);
+$pdf->SetFont($fontName, 'B', 11);
 $pdf->Cell(0, 8, enc('Genel Toplam: ' . number_format($total, 2, ',', '.')), 0, 1, 'R');
 
-$pdf->Output('I', 'teklif.pdf');
+try {
+    $pdf->Output('I', 'teklif.pdf');
+} catch (Throwable $e) {
+    error_log('PDF Output error: ' . $e->getMessage());
+    http_response_code(500);
+    echo 'PDF oluşturulurken bir hata oluştu.';
+}

--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+
+// Capture any stray output to avoid corrupting the PDF stream
+if (ob_get_level() === 0) {
+    ob_start();
+}
+
 if (empty($_SESSION['user_id'])) {
     http_response_code(403);
     exit('Forbidden');
@@ -215,6 +221,9 @@ h1 { font-size: 16pt; margin: 0 0 8pt; }
         }
         $mpdf = new \Mpdf\Mpdf(['tempDir' => $mpdfTemp]);
         $mpdf->WriteHTML($html);
+        if (ob_get_length()) {
+            ob_end_clean();
+        }
         $mpdf->Output('teklif.pdf', \Mpdf\Output\Destination::INLINE);
         exit;
     } catch (Throwable $e) {
@@ -323,6 +332,7 @@ try {
         ob_end_clean();
     }
     $pdf->Output('I', 'teklif.pdf');
+    exit;
 } catch (Throwable $e) {
     error_log('PDF Output error: ' . $e->getMessage());
     http_response_code(500);


### PR DESCRIPTION
## Summary
- Add Roboto font support and custom font path for FPDF
- Use common `enc()` function and robust error handling for quotation PDF generation

## Testing
- `php -l pdf/render_quotation_pdf.php`

------
https://chatgpt.com/codex/tasks/task_e_68a80d7679cc83288a2b62be94f3434f