### PR TITLE
Add approval workflow for quotations

### DIFF
--- a/pdf/preview.php
+++ b/pdf/preview.php
@@ -32,6 +32,7 @@ $guillotines = [];
 $slidings = [];
 $systems = [];
 $error = null;
+$approveUrl = '';
 
 try {
     $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id WHERE g.id = :id');
@@ -70,6 +71,11 @@ try {
     $uStmt->execute([':id' => $userId]);
     $u = $uStmt->fetch(PDO::FETCH_ASSOC);
     $preparedBy = $u['full_name'] ?: ($u['username'] ?? '');
+    if (!empty($quote['approval_token'])) {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+        $approveUrl = $host ? $scheme . '://' . $host . '/approve.php?token=' . urlencode($quote['approval_token']) : '';
+    }
 } catch (Throwable $e) {
     error_log($e->getMessage());
     $error = 'Veriler yüklenemedi.';
@@ -198,6 +204,9 @@ if (!empty($quote['offer_date']) && !empty($quote['validity_days'])) {
                             <div><span class="fw-semibold">Teklif No:</span> <?= h($quote['quote_no'] ?? '') ?></div>
                             <div><span class="fw-semibold">Tarih:</span> <?= h($quote['offer_date'] ?? '') ?></div>
                             <div><span class="fw-semibold">Hazırlayan:</span> <?= h($preparedBy) ?></div>
+                            <?php if ($approveUrl): ?>
+                            <div><span class="fw-semibold">Onay:</span> <a href="<?= h($approveUrl) ?>"><?= h($approveUrl) ?></a></div>
+                            <?php endif; ?>
                             <div><span class="fw-semibold">E-posta:</span> <?= h($company['email']) ?></div>
                         </div>
                     </div>

--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -35,6 +35,7 @@ if (!$id) {
 
 $guillotines = [];
 $slidings    = [];
+$approveUrl  = '';
 try {
     // Quote master
     $stmt = $pdo->prepare("
@@ -52,6 +53,11 @@ try {
     if (!$quote) {
         http_response_code(404);
         exit('Quotation not found.');
+    }
+    if (!empty($quote['approval_token'])) {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+        $approveUrl = $host ? $scheme . '://' . $host . '/approve.php?token=' . urlencode($quote['approval_token']) : '';
     }
 
     // Quote items (try a couple of likely tables; prefer generic quote_items if exists)
@@ -127,7 +133,7 @@ $canUseMpdf = class_exists('\\Mpdf\\Mpdf');
 
 if ($canUseMpdf) {
     // Build HTML via template if exists, else inline template
-    $html = (function() use ($quote, $guillotines, $slidings, $company, $assemblyText, $paymentText, $validityText) {
+    $html = (function() use ($quote, $guillotines, $slidings, $company, $assemblyText, $paymentText, $validityText, $items, $approveUrl) {
         $tpl = __DIR__ . '/templates/quotation.tpl.php';
         if (is_file($tpl)) {
             // The template should read $quote, $items, $company, etc.
@@ -197,6 +203,7 @@ h1 { font-size: 16pt; margin: 0 0 8pt; }
   '.($assemblyText ? '<div class="small">Montaj: '.h($assemblyText).'</div>' : '').'
   '.($paymentText ? '<div class="small">Ödeme: '.h($paymentText).'</div>' : '').'
   '.($validityText ? '<div class="small">Geçerlilik: '.h($validityText).'</div>' : '').'
+  '.($approveUrl ? '<div class="small">Onay: <a href="'.h($approveUrl).'">'.h($approveUrl).'</a></div>' : '').'
   <br>
   <h3>Giyotin Sistemleri</h3>
   '.($gRows ? '<table class="table"><thead><tr><th>Sistem</th><th>En</th><th>Boy</th><th>Adet</th><th>Cam</th><th>Motor</th><th>RAL</th><th class="text-right">Toplam</th></tr></thead><tbody>'.$gRows.'</tbody></table>' : '<p>Giyotin sistemi bulunamadı.</p>').'
@@ -233,6 +240,8 @@ $pdf->Cell(0, 6, enc('Müşteri: ' . $customerFull), 0, 1);
 if (!empty($assemblyText)) { $pdf->Cell(0, 6, enc('Montaj: ' . $assemblyText), 0, 1); }
 if (!empty($paymentText))  { $pdf->Cell(0, 6, enc('Ödeme: ' . $paymentText), 0, 1); }
 if (!empty($validityText)) { $pdf->Cell(0, 6, enc('Geçerlilik: ' . $validityText), 0, 1); }
+$haveApprove = !empty($approveUrl);
+if ($haveApprove) { $pdf->Cell(0, 6, enc('Onay: ' . $approveUrl), 0, 1); }
 $pdf->Ln(2);
 
 $total = 0.0;

--- a/public/approve.php
+++ b/public/approve.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../config.php';
+
+function h(?string $v): string
+{
+    return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+$token = $_GET['token'] ?? '';
+if ($token === '') {
+    http_response_code(400);
+    exit('Geçersiz bağlantı.');
+}
+
+$stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id WHERE g.approval_token = :t LIMIT 1');
+$stmt->execute([':t' => $token]);
+$offer = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$offer) {
+    http_response_code(404);
+    exit('Teklif bulunamadı.');
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $decision = $_POST['decision'] ?? '';
+    if (in_array($decision, ['accepted', 'rejected'], true)) {
+        $upd = $pdo->prepare('UPDATE generaloffers SET status = :st, approved_at = NOW() WHERE id = :id');
+        $upd->execute([':st' => $decision, ':id' => $offer['id']]);
+        $offer['status'] = $decision;
+        $offer['approved_at'] = date('Y-m-d H:i:s');
+        $message = $decision === 'accepted' ? 'Teklif onaylandı.' : 'Teklif reddedildi.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Teklif Onayı</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <h1 class="mb-4">Teklif Onayı</h1>
+    <?php if ($message): ?>
+        <div class="alert alert-info"><?= h($message) ?></div>
+    <?php endif; ?>
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="mb-2"><strong>Teklif No:</strong> <?= h($offer['quote_no'] ?? (string)$offer['id']) ?></div>
+            <div class="mb-2"><strong>Müşteri:</strong> <?= h(trim(($offer['first_name'] ?? '') . ' ' . ($offer['last_name'] ?? ''))) ?></div>
+            <?php if (!empty($offer['customer_company'])): ?>
+                <div class="mb-2"><strong>Firma:</strong> <?= h($offer['customer_company']) ?></div>
+            <?php endif; ?>
+            <div class="mb-2"><strong>Tarih:</strong> <?= h($offer['offer_date'] ?? '') ?></div>
+            <div class="mb-2"><strong>Durum:</strong> <?= h($offer['status']) ?></div>
+            <?php if (!empty($offer['approved_at'])): ?>
+                <div class="mb-2"><strong>Onay Tarihi:</strong> <?= h($offer['approved_at']) ?></div>
+            <?php endif; ?>
+        </div>
+    </div>
+    <form method="post" class="d-flex gap-2">
+        <input type="hidden" name="token" value="<?= h($token) ?>">
+        <button type="submit" name="decision" value="accepted" class="btn btn-success">Onayla</button>
+        <button type="submit" name="decision" value="rejected" class="btn btn-danger">Reddet</button>
+    </form>
+</div>
+</body>
+</html>

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -487,6 +487,9 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                             <strong>Durum:</strong> <?= e($statusLabels[$offer['status']] ?? $offer['status']) ?>
                         <?php endif; ?>
                     </div>
+                    <?php if (!empty($offer['approved_at'])): ?>
+                        <div class="mb-2"><strong>Onay Tarihi:</strong> <?= e($offer['approved_at']) ?></div>
+                    <?php endif; ?>
                 </div>
                 <div class="col-md-6">
                     <?php if (!empty($offer['company_name']) || !empty($offer['customer_company'])): ?>

--- a/quotations.php
+++ b/quotations.php
@@ -49,6 +49,8 @@ try {
     $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS total_with_interest DECIMAL(12,2) NULL AFTER interest_amount");
     $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS monthly_installment DECIMAL(12,2) NULL AFTER total_with_interest");
     $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS grace_days INT NULL DEFAULT 0 AFTER monthly_installment");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS approval_token VARCHAR(64) NULL AFTER profit_amount");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS approved_at DATETIME NULL AFTER approval_token");
 } catch (Exception $e) {
     // ignore migration errors
 }
@@ -83,6 +85,7 @@ $headers = [
     ['label' => 'Vade', 'key' => 'installment_term'],
     ['label' => 'Tarih', 'key' => 'offer_date'],
     ['label' => 'Tutar', 'key' => 'total_amount'],
+    ['label' => 'Onay Tarihi', 'key' => 'approved_at'],
     ['label' => 'Durum', 'key' => 'status'],
     ['label' => 'İşlemler', 'key' => null],
 ];
@@ -95,6 +98,7 @@ $allowedSorts = [
     'installment_term' => 'g.installment_term',
     'offer_date' => 'g.offer_date',
     'total_amount' => 'total_amount',
+    'approved_at' => 'g.approved_at',
     'status' => 'g.status',
 ];
 $sort = $_GET['sort'] ?? 'offer_date';
@@ -182,7 +186,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
 
     if (!$createErrors) {
         try {
-            $stmt = $pdo->prepare("INSERT INTO generaloffers (customer_id, offer_date, assembly_type, payment_method, validity_days, installment_term, term_months, interest_value) VALUES (:customer_id, :offer_date, :assembly_type, :payment_method, :validity_days, :installment_term, :term_months, :interest_value)");
+            $approvalToken = bin2hex(random_bytes(16));
+            $stmt = $pdo->prepare("INSERT INTO generaloffers (customer_id, offer_date, assembly_type, payment_method, validity_days, installment_term, term_months, interest_value, approval_token) VALUES (:customer_id, :offer_date, :assembly_type, :payment_method, :validity_days, :installment_term, :term_months, :interest_value, :approval_token)");
             $stmt->bindValue(':customer_id', $customerId, PDO::PARAM_INT);
             $stmt->bindValue(':offer_date', $offerDate);
             $stmt->bindValue(':assembly_type', $assembly);
@@ -191,6 +196,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
             $stmt->bindValue(':installment_term', $term !== '' ? $term : null, $term === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
             $stmt->bindValue(':term_months', $termMonths !== '' ? (int)$termMonths : null, $termMonths === '' ? PDO::PARAM_NULL : PDO::PARAM_INT);
             $stmt->bindValue(':interest_value', $interest !== '' ? $interest : null, $interest === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $stmt->bindValue(':approval_token', $approvalToken);
             $stmt->execute();
             $newId = (int)$pdo->lastInsertId();
             $_SESSION['flash_success'] = 'Teklif oluşturuldu.';
@@ -232,7 +238,7 @@ $totalRows = (int)$countStmt->fetchColumn();
 $totalPages = (int)max(1, ceil($totalRows / $perPage));
 if ($page > $totalPages) { $page = $totalPages; }
 $offset = ($page - 1) * $perPage;
-$selectSql = 'SELECT g.id, g.offer_date, g.status, g.assembly_type, g.payment_method, g.validity_days, g.installment_term, g.term_months, g.interest_value, CONCAT(c.first_name, " ", c.last_name) AS customer, c.company_name AS company,
+$selectSql = 'SELECT g.id, g.offer_date, g.status, g.approved_at, g.assembly_type, g.payment_method, g.validity_days, g.installment_term, g.term_months, g.interest_value, CONCAT(c.first_name, " ", c.last_name) AS customer, c.company_name AS company,
         COALESCE(gs.sum_total,0)+COALESCE(ss.sum_total,0) AS total_amount ' . $baseSql . ' ORDER BY ' . $orderSql . ' LIMIT :limit OFFSET :offset';
 $stmt = $pdo->prepare($selectSql);
 foreach ($params as $k => $v) { $stmt->bindValue(':' . $k, $v); }
@@ -316,6 +322,7 @@ unset($_SESSION['flash_error']);
   </td>
   <td><time datetime="<?= e($o['offer_date']) ?>"><?= e($o['offer_date']) ?></time></td>
   <td><?= number_format((float)$o['total_amount'],2,',','.') ?> ₺</td>
+  <td><?= $o['approved_at'] ? e($o['approved_at']) : '' ?></td>
   <td><?= e($statusLabels[$o['status']] ?? $o['status']) ?></td>
   <td class="text-center">
     <a href="quotation_view.php?id=<?= (int)$o['id'] ?>" class="btn btn-sm btn-outline-secondary" title="Görüntüle"><i class="bi bi-eye"></i></a>
@@ -328,7 +335,7 @@ unset($_SESSION['flash_error']);
   </td>
 </tr>
 <?php endforeach; else: ?>
-<tr><td colspan="10" class="text-center text-muted">Teklif bulunamadı.</td></tr>
+<tr><td colspan="11" class="text-center text-muted">Teklif bulunamadı.</td></tr>
 <?php endif; ?>
   </tbody>
 </table>

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -122,6 +122,8 @@ CREATE TABLE `generaloffers` (
   `total_amount` decimal(15,2) DEFAULT NULL,
   `profit_percent` decimal(5,2) DEFAULT NULL,
   `profit_amount` decimal(15,2) DEFAULT NULL,
+  `approval_token` varchar(64) DEFAULT NULL,
+  `approved_at` datetime DEFAULT NULL,
   `status` varchar(20) NOT NULL DEFAULT 'pending'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
@@ -129,9 +131,9 @@ CREATE TABLE `generaloffers` (
 -- Tablo döküm verisi `generaloffers`
 --
 
-INSERT INTO `generaloffers` (`id`, `quote_no`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `validity_days`, `installment_term`, `payment_type`, `term_months`, `interest_mode`, `interest_value`, `interest_amount`, `total_with_interest`, `monthly_installment`, `grace_days`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`, `profit_percent`, `profit_amount`, `status`) VALUES
-(9, NULL, 1, NULL, '2025-08-14', 'demonte', NULL, 'cash', 10, '0', 'installment', 10, 'percent', 10.00, 0.00, 0.00, 0.00, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00, 0.00, 0.00, 'pending'),
-(10, NULL, 1, NULL, '2025-08-15', 'demonte', NULL, 'cash', 10, '3', 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, 0.00, NULL, 0.00, 0.00, NULL, NULL, 'pending');
+INSERT INTO `generaloffers` (`id`, `quote_no`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `validity_days`, `installment_term`, `payment_type`, `term_months`, `interest_mode`, `interest_value`, `interest_amount`, `total_with_interest`, `monthly_installment`, `grace_days`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`, `profit_percent`, `profit_amount`, `approval_token`, `approved_at`, `status`) VALUES
+(9, NULL, 1, NULL, '2025-08-14', 'demonte', NULL, 'cash', 10, '0', 'installment', 10, 'percent', 10.00, 0.00, 0.00, 0.00, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00, 0.00, 0.00, NULL, NULL, 'pending'),
+(10, NULL, 1, NULL, '2025-08-15', 'demonte', NULL, 'cash', 10, '3', 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, 0.00, NULL, 0.00, 0.00, NULL, NULL, NULL, NULL, 'pending');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add approval_token and approved_at columns
- generate approval links and handle approvals via new public page
- surface approval status and date in lists, previews, and PDFs

## Testing
- `php -l quotations.php public/approve.php pdf/preview.php pdf/render_quotation_pdf.php quotation_view.php`

------
https://chatgpt.com/codex/tasks/task_e_68a84cb686148328b73b48b21f4546a1