### PR TITLE
Fix approval link path

### DIFF
--- a/pdf/preview.php
+++ b/pdf/preview.php
@@ -74,7 +74,7 @@ try {
     if (!empty($quote['approval_token'])) {
         $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
         $host = $_SERVER['HTTP_HOST'] ?? '';
-        $approveUrl = $host ? $scheme . '://' . $host . '/approve.php?token=' . urlencode($quote['approval_token']) : '';
+        $approveUrl = $host ? $scheme . '://' . $host . '/public/approve.php?token=' . urlencode($quote['approval_token']) : '';
     }
 } catch (Throwable $e) {
     error_log($e->getMessage());

--- a/pdf/render_quotation_pdf.php
+++ b/pdf/render_quotation_pdf.php
@@ -57,7 +57,7 @@ try {
     if (!empty($quote['approval_token'])) {
         $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
         $host = $_SERVER['HTTP_HOST'] ?? '';
-        $approveUrl = $host ? $scheme . '://' . $host . '/approve.php?token=' . urlencode($quote['approval_token']) : '';
+        $approveUrl = $host ? $scheme . '://' . $host . '/public/approve.php?token=' . urlencode($quote['approval_token']) : '';
     }
 
     // Quote items (try a couple of likely tables; prefer generic quote_items if exists)

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -270,7 +270,7 @@ $approveUrl = '';
 if (!empty($offer['approval_token'])) {
     $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
     $host   = $_SERVER['HTTP_HOST'] ?? '';
-    $approveUrl = $host ? $scheme . '://' . $host . '/approve.php?token=' . urlencode($offer['approval_token']) : '';
+    $approveUrl = $host ? $scheme . '://' . $host . '/public/approve.php?token=' . urlencode($offer['approval_token']) : '';
 }
 
 $gDel = ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'delete_guillotine' && $role === 'admin');


### PR DESCRIPTION
## Summary
- Correct approval URL generation to point to public/approve.php so shared links no longer 404

## Testing
- `php -l quotation_view.php`
- `php -l pdf/render_quotation_pdf.php`
- `php -l pdf/preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8581ab934832895f878bf34d9d1b7