### PR TITLE
Hide approval link in quotation view

### DIFF
--- a/app/Controllers/quotation_view.php
+++ b/app/Controllers/quotation_view.php
@@ -477,7 +477,10 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                         <div class="mb-2"><strong>Ödeme:</strong> <?= e($paymentLabels[$offer['payment_method']] ?? $offer['payment_method']) ?></div>
                     <?php endif; ?>
                     <?php if ($approveUrl): ?>
-                        <div class="mb-2"><strong>Onay:</strong> <a href="<?= e($approveUrl) ?>"><?= e($approveUrl) ?></a><button type="button" class="btn btn-sm btn-outline-secondary share-btn ms-2" data-url="<?= e($approveUrl) ?>">Paylaş</button></div>
+                        <div class="mb-2">
+                            <strong>Onay:</strong>
+                            <button type="button" class="btn btn-sm btn-outline-secondary share-btn" data-url="<?= e($approveUrl) ?>">Paylaş</button>
+                        </div>
                     <?php endif; ?>
                     <div class="mb-2">
                         <?php if ($role === 'admin'): ?>


### PR DESCRIPTION
## Summary
- Hide approval link in quotation view by removing anchor and keeping share button

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a953d9071883288f68f9a87f3f0fa0