### PR TITLE
feat: add notes to general offers

### DIFF
--- a/app/Controllers/quotation_edit.php
+++ b/app/Controllers/quotation_edit.php
@@ -51,6 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $installmentTerm = trim($_POST['installment_term'] ?? '');
   $termMonths      = trim($_POST['term_months'] ?? '');
   $interestValue   = trim($_POST['interest_value'] ?? '');
+  $note            = trim($_POST['note'] ?? '');
 
   if ($customerId <= 0) {
     $errors['customer_id'] = 'Müşteri zorunludur.';
@@ -89,9 +90,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $interestValue = '';
   }
 
+  if ($note !== '' && mb_strlen($note) > 1000) {
+    $errors['note'] = 'Not en fazla 1000 karakter olabilir.';
+  }
+
   if (!$errors) {
     try {
-      $stmt = $pdo->prepare('UPDATE generaloffers SET customer_id=:customer_id, offer_date=:offer_date, assembly_type=:assembly_type, payment_method=:payment_method, validity_days=:validity_days, installment_term=:installment_term, term_months=:term_months, interest_value=:interest_value WHERE id=:id');
+      $stmt = $pdo->prepare('UPDATE generaloffers SET customer_id=:customer_id, offer_date=:offer_date, assembly_type=:assembly_type, payment_method=:payment_method, validity_days=:validity_days, installment_term=:installment_term, term_months=:term_months, interest_value=:interest_value, note=:note WHERE id=:id');
       $stmt->bindValue(':customer_id', $customerId, PDO::PARAM_INT);
       $stmt->bindValue(':offer_date', $offerDate);
       $stmt->bindValue(':assembly_type', $assemblyType);
@@ -100,6 +105,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       $stmt->bindValue(':installment_term', $installmentTerm !== '' ? $installmentTerm : null, $installmentTerm === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
       $stmt->bindValue(':term_months', $termMonths !== '' ? (int)$termMonths : null, $termMonths === '' ? PDO::PARAM_NULL : PDO::PARAM_INT);
       $stmt->bindValue(':interest_value', $interestValue !== '' ? $interestValue : null, $interestValue === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
+      $cleanNote = $note !== '' ? strip_tags($note) : null;
+      $stmt->bindValue(':note', $cleanNote, $cleanNote === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
       $stmt->bindValue(':id', $id, PDO::PARAM_INT);
       $stmt->execute();
       $success = 'Teklif güncellendi.';
@@ -112,6 +119,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'installment_term' => $installmentTerm,
         'term_months'      => $termMonths !== '' ? (int)$termMonths : null,
         'interest_value'   => $interestValue !== '' ? $interestValue : null,
+        'note'             => $cleanNote,
       ]);
     } catch (Exception $e) {
       $errors['form'] = 'Güncellenemedi.';
@@ -175,6 +183,11 @@ page_header('Teklifi Düzenle');
     <label class="form-label">Vade</label>
     <input type="text" name="installment_term" class="form-control <?= isset($errors['installment_term']) ? 'is-invalid' : '' ?>" value="<?= e($offer['installment_term'] ?? '') ?>" placeholder="3 taksit (aylık)">
     <?php if (isset($errors['installment_term'])): ?><div class="invalid-feedback"><?= e($errors['installment_term']) ?></div><?php endif; ?>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <textarea name="note" rows="3" class="form-control <?= isset($errors['note']) ? 'is-invalid' : '' ?>"><?= e($offer['note'] ?? '') ?></textarea>
+    <?php if (isset($errors['note'])): ?><div class="invalid-feedback"><?= e($errors['note']) ?></div><?php endif; ?>
   </div>
   <div class="mb-3">
     <label class="form-label">Teklif Tarihi</label>

--- a/app/Controllers/quotation_view.php
+++ b/app/Controllers/quotation_view.php
@@ -518,6 +518,9 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                     <div class="mb-2"><strong>Toplam Tutar:</strong> <?= e($totalFormatted) ?></div>
                 </div>
             </div>
+            <?php if (!empty($offer['note'])): ?>
+                <div class="mt-3"><strong>Not:</strong><br><?= nl2br(e($offer['note'])) ?></div>
+            <?php endif; ?>
         </div>
     </div>
 

--- a/app/Controllers/quotations.php
+++ b/app/Controllers/quotations.php
@@ -56,6 +56,7 @@ try {
   $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS grace_days INT NULL DEFAULT 0 AFTER monthly_installment");
   $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS approval_token VARCHAR(64) NULL AFTER profit_amount");
   $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS approved_at DATETIME NULL AFTER approval_token");
+  $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS note TEXT NULL AFTER approved_at");
 } catch (Exception $e) {
   // ignore migration errors
 }
@@ -124,6 +125,7 @@ $createData = [
   'installment_term' => '',
   'term_months' => '',
   'interest_value' => '',
+  'note' => '',
 ];
 
 $action = $_POST['action'] ?? '';
@@ -138,6 +140,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
   $term       = trim($_POST['installment_term'] ?? '');
   $termMonths = trim($_POST['term_months'] ?? '');
   $interest   = trim($_POST['interest_value'] ?? '');
+  $note       = trim($_POST['note'] ?? '');
 
   $createData = [
     'customer_id'      => $customerId ? (string)$customerId : '',
@@ -148,6 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
     'installment_term' => $term,
     'term_months'      => $termMonths,
     'interest_value'   => $interest,
+    'note'             => $note,
   ];
 
   if (!hash_equals($csrfToken, $token)) {
@@ -189,10 +193,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
     $interest = '';
   }
 
+  if ($note !== '' && mb_strlen($note) > 1000) {
+    $createErrors['note'] = 'Not en fazla 1000 karakter olabilir.';
+  }
+
   if (!$createErrors) {
     try {
       $approvalToken = bin2hex(random_bytes(16));
-      $stmt = $pdo->prepare("INSERT INTO generaloffers (customer_id, offer_date, assembly_type, payment_method, validity_days, installment_term, term_months, interest_value, approval_token) VALUES (:customer_id, :offer_date, :assembly_type, :payment_method, :validity_days, :installment_term, :term_months, :interest_value, :approval_token)");
+      $stmt = $pdo->prepare("INSERT INTO generaloffers (customer_id, offer_date, assembly_type, payment_method, validity_days, installment_term, term_months, interest_value, note, approval_token) VALUES (:customer_id, :offer_date, :assembly_type, :payment_method, :validity_days, :installment_term, :term_months, :interest_value, :note, :approval_token)");
       $stmt->bindValue(':customer_id', $customerId, PDO::PARAM_INT);
       $stmt->bindValue(':offer_date', $offerDate);
       $stmt->bindValue(':assembly_type', $assembly);
@@ -201,6 +209,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
       $stmt->bindValue(':installment_term', $term !== '' ? $term : null, $term === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
       $stmt->bindValue(':term_months', $termMonths !== '' ? (int)$termMonths : null, $termMonths === '' ? PDO::PARAM_NULL : PDO::PARAM_INT);
       $stmt->bindValue(':interest_value', $interest !== '' ? $interest : null, $interest === '' ? PDO::PARAM_NULL : PDO::PARAM_STR);
+      $cleanNote = $note !== '' ? strip_tags($note) : null;
+      $stmt->bindValue(':note', $cleanNote, $cleanNote === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
       $stmt->bindValue(':approval_token', $approvalToken);
       $stmt->execute();
       $newId = (int)$pdo->lastInsertId();
@@ -485,6 +495,11 @@ $customers = $pdo->query('SELECT id, first_name, last_name, company_name AS comp
             <label class="form-label">Vade</label>
             <input type="text" name="installment_term" class="form-control <?= isset($createErrors['installment_term']) ? 'is-invalid' : '' ?>" value="<?= e($createData['installment_term']) ?>" placeholder="3 taksit (aylık)">
             <?php if (isset($createErrors['installment_term'])): ?><div class="invalid-feedback"><?= e($createErrors['installment_term']) ?></div><?php endif; ?>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Not</label>
+            <textarea name="note" rows="3" class="form-control <?= isset($createErrors['note']) ? 'is-invalid' : '' ?>"><?= e($createData['note']) ?></textarea>
+            <?php if (isset($createErrors['note'])): ?><div class="invalid-feedback"><?= e($createErrors['note']) ?></div><?php endif; ?>
           </div>
           <div class="mb-3">
             <label class="form-label">Teklif Tarihi</label>

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -124,6 +124,7 @@ CREATE TABLE `generaloffers` (
   `profit_amount` decimal(15,2) DEFAULT NULL,
   `approval_token` varchar(64) DEFAULT NULL,
   `approved_at` datetime DEFAULT NULL,
+  `note` text DEFAULT NULL,
   `status` varchar(20) NOT NULL DEFAULT 'pending'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
@@ -131,9 +132,9 @@ CREATE TABLE `generaloffers` (
 -- Tablo döküm verisi `generaloffers`
 --
 
-INSERT INTO `generaloffers` (`id`, `quote_no`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `validity_days`, `installment_term`, `payment_type`, `term_months`, `interest_mode`, `interest_value`, `interest_amount`, `total_with_interest`, `monthly_installment`, `grace_days`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`, `profit_percent`, `profit_amount`, `approval_token`, `approved_at`, `status`) VALUES
-(9, NULL, 1, NULL, '2025-08-14', 'demonte', NULL, 'cash', 10, '0', 'installment', 10, 'percent', 10.00, 0.00, 0.00, 0.00, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00, 0.00, 0.00, NULL, NULL, 'pending'),
-(10, NULL, 1, NULL, '2025-08-15', 'demonte', NULL, 'cash', 10, '3', 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, 0.00, NULL, 0.00, 0.00, NULL, NULL, NULL, NULL, 'pending');
+INSERT INTO `generaloffers` (`id`, `quote_no`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `validity_days`, `installment_term`, `payment_type`, `term_months`, `interest_mode`, `interest_value`, `interest_amount`, `total_with_interest`, `monthly_installment`, `grace_days`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`, `profit_percent`, `profit_amount`, `approval_token`, `approved_at`, `note`, `status`) VALUES
+(9, NULL, 1, NULL, '2025-08-14', 'demonte', NULL, 'cash', 10, '0', 'installment', 10, 'percent', 10.00, 0.00, 0.00, 0.00, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00, 0.00, 0.00, NULL, NULL, NULL, 'pending'),
+(10, NULL, 1, NULL, '2025-08-15', 'demonte', NULL, 'cash', 10, '3', 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, 0.00, NULL, 0.00, 0.00, NULL, NULL, NULL, NULL, NULL, 'pending');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- allow general offers to include optional note text and store it in the database
- expose note editing in quotation creation and update flows
- show saved notes in offer detail pages

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a95680f69883289a1e264358137fab