### PR TITLE
Ensure test controller loads bootstrap for direct execution

### DIFF
--- a/app/Controllers/test.php
+++ b/app/Controllers/test.php
@@ -286,6 +286,7 @@ function calculateGuillotineTotals(array $input): array
 }
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    require_once __DIR__ . '/../../bootstrap.php';
     require BASE_PATH . '/header.php';
 
     function e(?string $v): string


### PR DESCRIPTION
## Summary
- load bootstrap before header when `app/Controllers/test.php` is executed directly

## Testing
- `php app/Controllers/test.php && echo 'script finished'`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a95b216e60832890cebeddfe5339e9