### PR TITLE
Initialize quotation form data to prevent 500 error

### DIFF
--- a/app/Controllers/quotations.php
+++ b/app/Controllers/quotations.php
@@ -118,6 +118,18 @@ $orderSql = $allowedSorts[$sort] . ' ' . $dir;
 $createErrors = [];
 $action = $_POST['action'] ?? '';
 
+$createData = [
+  'customer_id'      => '',
+  'offer_date'       => date('Y-m-d'),
+  'assembly_type'    => '',
+  'payment_method'   => '',
+  'validity_days'    => '',
+  'installment_term' => '',
+  'term_months'      => '',
+  'interest_value'   => '',
+  'note'             => '',
+];
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
   $token      = $_POST['csrf_token'] ?? '';
   $customerId = (int)($_POST['customer_id'] ?? 0);


### PR DESCRIPTION
## Summary
- define default `$createData` array so GET requests don't trigger undefined variable errors in `quotations.php`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a95e5486d883289fe28525ddd9fa1b