### PR TITLE
Prevent bootstrap from being included twice in error pages

### DIFF
--- a/resources/views/errors/403.php
+++ b/resources/views/errors/403.php
@@ -1,6 +1,6 @@
 <?php
 http_response_code(403);
-require __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 ?>
 <!doctype html>
 <html lang="tr">

--- a/resources/views/errors/404.php
+++ b/resources/views/errors/404.php
@@ -1,6 +1,6 @@
 <?php
 http_response_code(404);
-require __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 ?>
 <!doctype html>
 <html lang="tr">

--- a/resources/views/errors/500.php
+++ b/resources/views/errors/500.php
@@ -1,6 +1,6 @@
 <?php
 http_response_code(500);
-require __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 ?>
 <!doctype html>
 <html lang="tr">


### PR DESCRIPTION
## Summary
- avoid redeclaring bootstrap by using `require_once` in 403/404/500 error views

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a95f27776883288db9818a9f2a74a0