### PR TITLE
Add price unit group to product modals

### DIFF
--- a/products.php
+++ b/products.php
@@ -482,7 +482,11 @@ require __DIR__ . '/header.php';
                           <div class="col-md-6">
                             <label class="form-label">Fiyat Birimi ve Fiyatı *</label>
                             <div class="input-group">
-                              <span class="input-group-text">TL</span>
+                              <select name="price_unit" class="form-select">
+                                <option value="TL">TL</option>
+                                <option value="USD">USD</option>
+                                <option value="EUR">EUR</option>
+                              </select>
                               <input type="number" step="10" name="unit_price" class="form-control" required value="<?= e($p['unit_price']) ?>">
                             </div>
                           </div>
@@ -602,7 +606,11 @@ require __DIR__ . '/header.php';
                 <div class="col-md-6">
                   <label class="form-label">Fiyat Birimi ve Fiyatı *</label>
                   <div class="input-group">
-                    <span class="input-group-text">TL</span>
+                    <select name="price_unit" class="form-select">
+                      <option value="TL" <?= (($_POST['price_unit'] ?? 'TL') === 'TL') ? 'selected' : '' ?>>TL</option>
+                      <option value="USD" <?= (($_POST['price_unit'] ?? 'TL') === 'USD') ? 'selected' : '' ?>>USD</option>
+                      <option value="EUR" <?= (($_POST['price_unit'] ?? 'TL') === 'EUR') ? 'selected' : '' ?>>EUR</option>
+                    </select>
                     <input type="number" step="0.01" name="unit_price" class="form-control" required>
                   </div>
                 </div>

--- a/products.php
+++ b/products.php
@@ -480,8 +480,11 @@ require __DIR__ . '/header.php';
                             <input type="text" name="color" class="form-control" value="<?= e($p['color']) ?>">
                           </div>
                           <div class="col-md-6">
-                            <label class="form-label">Fiyat *</label>
-                            <input type="number" step="10" name="unit_price" class="form-control" required value="<?= e($p['unit_price']) ?>">
+                            <label class="form-label">Fiyat Birimi ve Fiyatı *</label>
+                            <div class="input-group">
+                              <span class="input-group-text">TL</span>
+                              <input type="number" step="10" name="unit_price" class="form-control" required value="<?= e($p['unit_price']) ?>">
+                            </div>
                           </div>
                           <?php
                           $allowedVat = [0, 1, 8, 18, 20];
@@ -597,8 +600,11 @@ require __DIR__ . '/header.php';
                   <input type="text" name="color" class="form-control">
                 </div>
                 <div class="col-md-6">
-                  <label class="form-label">Fiyat *</label>
-                  <input type="number" step="0.01" name="unit_price" class="form-control" required>
+                  <label class="form-label">Fiyat Birimi ve Fiyatı *</label>
+                  <div class="input-group">
+                    <span class="input-group-text">TL</span>
+                    <input type="number" step="0.01" name="unit_price" class="form-control" required>
+                  </div>
                 </div>
                 <div class="col-md-6">
                   <label class="form-label">KDV Oranı</label>


### PR DESCRIPTION
## Summary
- Show currency prefix with price input in edit product modal
- Show currency prefix with price input in new product modal

## Testing
- `php -l products.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac373136fc832892e3625883181a46