### PR TITLE
Join categories when fetching product data

### DIFF
--- a/test.php
+++ b/test.php
@@ -312,7 +312,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
 
         public function getProduct(string $name): ?array
         {
-            $stmt = $this->pdo->prepare('SELECT unit, unit_price, weight_per_meter, category FROM products WHERE LOWER(name) = LOWER(:name)');
+            $stmt = $this->pdo->prepare('SELECT p.unit, p.unit_price, p.weight_per_meter, c.name AS category FROM products p LEFT JOIN categories c ON p.category_id = c.id WHERE LOWER(p.name) = LOWER(:name)');
             $stmt->execute([':name' => $name]);
 
             $row = $stmt->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- Use LEFT JOIN in `PdoProductProvider::getProduct` to retrieve category names

## Testing
- `php -l test.php`
- `php test.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac4343cc00832897e8199d036b295f