### PR TITLE
Join categories table when fetching product details

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -14,7 +14,11 @@ class PdoProductProvider implements ProductProviderInterface
 
     public function getProduct(string $name): ?array
     {
-        $stmt = $this->pdo->prepare('SELECT unit, unit_price, vat_rate, weight_per_meter, category FROM products WHERE LOWER(name) = LOWER(:name)');
+        $stmt = $this->pdo->prepare(
+            'SELECT p.unit, p.unit_price, p.vat_rate, p.weight_per_meter, c.name AS category '
+            . 'FROM products p LEFT JOIN categories c ON p.category_id = c.id '
+            . 'WHERE LOWER(p.name) = LOWER(:name)'
+        );
         $stmt->execute([':name' => $name]);
 
         $row = $stmt->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- Replace product lookup query to left-join categories and select `c.name AS category`

## Testing
- `php -l quotation_view.php`
- `php /tmp/guillotine_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac471762c483289f50be0906e6752d