### PR TITLE
Add 'set' option to product unit types

### DIFF
--- a/products.php
+++ b/products.php
@@ -30,7 +30,7 @@ $error = null;
 $success = null;
 $vatAllowed = [0, 1, 8, 18, 20];
 $action = $_POST['action'] ?? $_GET['action'] ?? '';
-$unitTypeOptions = ['kg/m', 'm', 'm²', 'adet'];
+$unitTypeOptions = ['kg/m', 'm', 'm²', 'adet', 'set'];
 
 // Fetch categories from database
 $categoryStmt = $pdo->query('SELECT id, name FROM categories ORDER BY name');


### PR DESCRIPTION
## Summary
- allow selecting "set" as a unit type in products

## Testing
- `php -l products.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac57ad32ec8328b70ce25ec6d8958e