### PR TITLE
Display USD and EUR exchange rates on test page

### DIFF
--- a/test.php
+++ b/test.php
@@ -569,6 +569,19 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     }
 
     echo '<div class="container mt-4">';
+    if (!empty($exchangeRates)) {
+        echo '<div class="alert alert-info mb-4">';
+        if (isset($exchangeRates['USD'])) {
+            echo '1 USD = ' . e(number_format($exchangeRates['USD'], 2, ',', '.')) . ' ' . e(currencySymbol('TRY'));
+        }
+        if (isset($exchangeRates['EUR'])) {
+            if (isset($exchangeRates['USD'])) {
+                echo '<br>';
+            }
+            echo '1 EUR = ' . e(number_format($exchangeRates['EUR'], 2, ',', '.')) . ' ' . e(currencySymbol('TRY'));
+        }
+        echo '</div>';
+    }
     echo '<h3>Kalemler</h3>';
 
     //


### PR DESCRIPTION
## Summary
- Show current USD and EUR exchange rates on test.php

## Testing
- `php -l test.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ad55a234708328916f0b8fa63186c8