### PR TITLE
Fetch exchange rates via helper for guillotine totals

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Fetches exchange rates for the given currencies relative to the base.
+ *
+ * The external API returns how much 1 unit of the base currency equals in the
+ * target currencies. This function returns multipliers from target currency to
+ * the base currency (i.e. reciprocal of API rate).
+ *
+ * @param string $base       Base currency code.
+ * @param array  $currencies Target currency codes.
+ *
+ * @return array<string,float>
+ */
+function fetchExchangeRates(string $base, array $currencies): array
+{
+    $base = strtoupper($base);
+    $json = @file_get_contents("https://open.er-api.com/v6/latest/{$base}");
+    $data = $json ? json_decode($json, true) : null;
+    if (!is_array($data) || (($data['result'] ?? '') !== 'success') || empty($data['rates'])) {
+        return [];
+    }
+    $rates = [];
+    foreach ($currencies as $cur) {
+        $curUpper = strtoupper($cur);
+        if ($curUpper === $base) {
+            $rates[$curUpper] = 1.0;
+            continue;
+        }
+        $rate = $data['rates'][$curUpper] ?? null;
+        if ($rate && $rate > 0) {
+            $rates[$curUpper] = 1 / $rate;
+        }
+    }
+    return $rates;
+}

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -1,6 +1,7 @@
 <?php
 require __DIR__ . '/header.php';
 require __DIR__ . '/components/page_header.php';
+require_once __DIR__ . '/helpers.php';
 require_once __DIR__ . '/test.php';
 
 function e(?string $v): string
@@ -138,13 +139,24 @@ if (
             if ((float)($row['width'] ?? 0) <= 0 || (float)($row['height'] ?? 0) <= 0 || (int)($row['quantity'] ?? 0) <= 0) {
                 throw new Exception('Geçersiz giyotin satırı.');
             }
+            $exchangeRates = fetchExchangeRates('TRY', ['USD', 'EUR']);
+            if (empty($exchangeRates)) {
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+                header('Content-Type: application/json', true, 500);
+                echo json_encode(['error' => 'Kur bilgileri alınamadı.']);
+                exit;
+            }
             $totals = calculateGuillotineTotals([
-                'width'       => $row['width'],
-                'height'      => $row['height'],
-                'quantity'    => $row['quantity'],
-                'glass_type'  => $row['glass_type'] ?? '',
-                'profit_rate' => $row['profit_rate'] ?? ($row['profit_margin'] ?? 0),
-                'provider'    => $productProvider,
+                'width'         => $row['width'],
+                'height'        => $row['height'],
+                'quantity'      => $row['quantity'],
+                'glass_type'    => $row['glass_type'] ?? '',
+                'profit_rate'   => $row['profit_rate'] ?? ($row['profit_margin'] ?? 0),
+                'currency'      => 'TRY',
+                'exchange_rates'=> $exchangeRates,
+                'provider'      => $productProvider,
             ]);
             $gUpd = $pdo->prepare('UPDATE guillotinesystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
             $gUpd->execute([
@@ -276,70 +288,77 @@ if ($gPost) {
             if (!$validNumbers) {
                 $error = 'Tüm sayısal alanlar pozitif olmalıdır.';
             } else {
-                if ($gId) {
-                    $sql = 'UPDATE guillotinesystems SET width=:width, height=:height, quantity=:quantity, motor_system=:motor, remote_quantity=:remote, ral_code=:ral, glass_type=:glass_type, glass_color=:glass_color, profit_margin=:profit_margin WHERE id=:id AND general_offer_id=:goid';
-                    $params = [
-                        ':width' => $width,
-                        ':height' => $height,
-                        ':quantity' => $quantity,
-                        ':motor' => $motor,
-                        ':remote' => $remoteQty,
-                        ':ral' => $ralCode,
-                        ':glass_type' => $glassType,
-                        ':glass_color' => $glassColor,
-                        ':profit_margin' => $profitMargin,
-                        ':id' => $gId,
-                        ':goid' => $id,
-                    ];
+                $exchangeRates = fetchExchangeRates('TRY', ['USD', 'EUR']);
+                if (empty($exchangeRates)) {
+                    $error = 'Kur bilgileri alınamadı.';
                 } else {
-                    $sql = 'INSERT INTO guillotinesystems (general_offer_id, system_type, width, height, quantity, motor_system, remote_quantity, ral_code, glass_type, glass_color, profit_margin) VALUES (:goid, :stype, :width, :height, :quantity, :motor, :remote, :ral, :glass_type, :glass_color, :profit_margin)';
-                    $params = [
-                        ':goid' => $id,
-                        ':stype' => 'Guillotine',
-                        ':width' => $width,
-                        ':height' => $height,
-                        ':quantity' => $quantity,
-                        ':motor' => $motor,
-                        ':remote' => $remoteQty,
-                        ':ral' => $ralCode,
-                        ':glass_type' => $glassType,
-                        ':glass_color' => $glassColor,
-                        ':profit_margin' => $profitMargin,
-                    ];
-                }
-                $stmt = $pdo->prepare($sql);
-                $stmt->execute($params);
+                    if ($gId) {
+                        $sql = 'UPDATE guillotinesystems SET width=:width, height=:height, quantity=:quantity, motor_system=:motor, remote_quantity=:remote, ral_code=:ral, glass_type=:glass_type, glass_color=:glass_color, profit_margin=:profit_margin WHERE id=:id AND general_offer_id=:goid';
+                        $params = [
+                            ':width' => $width,
+                            ':height' => $height,
+                            ':quantity' => $quantity,
+                            ':motor' => $motor,
+                            ':remote' => $remoteQty,
+                            ':ral' => $ralCode,
+                            ':glass_type' => $glassType,
+                            ':glass_color' => $glassColor,
+                            ':profit_margin' => $profitMargin,
+                            ':id' => $gId,
+                            ':goid' => $id,
+                        ];
+                    } else {
+                        $sql = 'INSERT INTO guillotinesystems (general_offer_id, system_type, width, height, quantity, motor_system, remote_quantity, ral_code, glass_type, glass_color, profit_margin) VALUES (:goid, :stype, :width, :height, :quantity, :motor, :remote, :ral, :glass_type, :glass_color, :profit_margin)';
+                        $params = [
+                            ':goid' => $id,
+                            ':stype' => 'Guillotine',
+                            ':width' => $width,
+                            ':height' => $height,
+                            ':quantity' => $quantity,
+                            ':motor' => $motor,
+                            ':remote' => $remoteQty,
+                            ':ral' => $ralCode,
+                            ':glass_type' => $glassType,
+                            ':glass_color' => $glassColor,
+                            ':profit_margin' => $profitMargin,
+                        ];
+                    }
+                    $stmt = $pdo->prepare($sql);
+                    $stmt->execute($params);
 
-                $gId = $gId ?: (int)$pdo->lastInsertId();
-                $gFetch = $pdo->prepare('SELECT * FROM guillotinesystems WHERE id = :gid AND general_offer_id = :goid');
-                $gFetch->execute([':gid' => $gId, ':goid' => $id]);
-                if ($row = $gFetch->fetch(PDO::FETCH_ASSOC)) {
-                    $totals = calculateGuillotineTotals([
-                        'width'       => $row['width'],
-                        'height'      => $row['height'],
-                        'quantity'    => $row['quantity'],
-                        'glass_type'  => $row['glass_type'] ?? '',
-                        'profit_rate' => $row['profit_rate'] ?? ($row['profit_margin'] ?? 0),
-                        'provider'    => $productProvider,
-                    ]);
-                    $gUpd = $pdo->prepare('UPDATE guillotinesystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
-                    $gUpd->execute([
-                        ':pamount' => $totals['totals']['profit'],
-                        ':tamount' => $totals['totals']['grand_total'],
-                        ':id' => $gId,
-                    ]);
-                }
+                    $gId = $gId ?: (int)$pdo->lastInsertId();
+                    $gFetch = $pdo->prepare('SELECT * FROM guillotinesystems WHERE id = :gid AND general_offer_id = :goid');
+                    $gFetch->execute([':gid' => $gId, ':goid' => $id]);
+                    if ($row = $gFetch->fetch(PDO::FETCH_ASSOC)) {
+                        $totals = calculateGuillotineTotals([
+                            'width'         => $row['width'],
+                            'height'        => $row['height'],
+                            'quantity'      => $row['quantity'],
+                            'glass_type'    => $row['glass_type'] ?? '',
+                            'profit_rate'   => $row['profit_rate'] ?? ($row['profit_margin'] ?? 0),
+                            'currency'      => 'TRY',
+                            'exchange_rates'=> $exchangeRates,
+                            'provider'      => $productProvider,
+                        ]);
+                        $gUpd = $pdo->prepare('UPDATE guillotinesystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
+                        $gUpd->execute([
+                            ':pamount' => $totals['totals']['profit'],
+                            ':tamount' => $totals['totals']['grand_total'],
+                            ':id' => $gId,
+                        ]);
+                    }
 
-                $gSumStmt = $pdo->prepare('SELECT COALESCE(SUM(total_amount),0) FROM guillotinesystems WHERE general_offer_id = :id');
-                $gSumStmt->execute([':id' => $id]);
-                $gSum = (float)$gSumStmt->fetchColumn();
-                $sSumStmt = $pdo->prepare('SELECT COALESCE(SUM(total_amount),0) FROM slidingsystems WHERE general_offer_id = :id');
-                $sSumStmt->execute([':id' => $id]);
-                $sSum = (float)$sSumStmt->fetchColumn();
-                $overall = $gSum + $sSum;
-                $updStmt = $pdo->prepare('UPDATE generaloffers SET total_amount = :total WHERE id = :id');
-                $updStmt->execute([':total' => $overall, ':id' => $id]);
-                $success = $gId ? 'Giyotin sistemi güncellendi.' : 'Giyotin sistemi eklendi.';
+                    $gSumStmt = $pdo->prepare('SELECT COALESCE(SUM(total_amount),0) FROM guillotinesystems WHERE general_offer_id = :id');
+                    $gSumStmt->execute([':id' => $id]);
+                    $gSum = (float)$gSumStmt->fetchColumn();
+                    $sSumStmt = $pdo->prepare('SELECT COALESCE(SUM(total_amount),0) FROM slidingsystems WHERE general_offer_id = :id');
+                    $sSumStmt->execute([':id' => $id]);
+                    $sSum = (float)$sSumStmt->fetchColumn();
+                    $overall = $gSum + $sSum;
+                    $updStmt = $pdo->prepare('UPDATE generaloffers SET total_amount = :total WHERE id = :id');
+                    $updStmt->execute([':total' => $overall, ':id' => $id]);
+                    $success = $gId ? 'Giyotin sistemi güncellendi.' : 'Giyotin sistemi eklendi.';
+                }
             }
         } catch (Exception $e) {
             $error = 'Giyotin sistemi kaydedilemedi.';

--- a/test.php
+++ b/test.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/helpers.php';
+
 //
 // Cam Birim Fiyatı
 // Cam fiyatı artık veritabanındaki ürün bilgilerinden alınır.
@@ -462,35 +464,6 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
         };
     }
 
-    //
-    // Kur Oranlarını Alma
-    // Belirtilen para birimleri için baz para birimine göre çeviri katsayısı döndürür.
-    //
-    function fetchExchangeRates(string $base, array $currencies): array
-    {
-        $base = strtoupper($base);
-        // New API does not support limiting symbols, so fetch all and filter.
-        $json = @file_get_contents("https://open.er-api.com/v6/latest/{$base}");
-        $data = $json ? json_decode($json, true) : null;
-        if (!is_array($data) || (($data['result'] ?? '') !== 'success') || empty($data['rates'])) {
-            return [];
-        }
-        $rates = [];
-        foreach ($currencies as $cur) {
-            $curUpper = strtoupper($cur);
-            if ($curUpper === $base) {
-                $rates[$curUpper] = 1.0;
-                continue;
-            }
-            $rate = $data['rates'][$curUpper] ?? null;
-            if ($rate && $rate > 0) {
-                // API returns how much 1 base currency equals in target currency.
-                // We need multiplier from target currency to base, so take reciprocal.
-                $rates[$curUpper] = 1 / $rate;
-            }
-        }
-        return $rates;
-    }
 
     //
     // PDO Ürün Sağlayıcı Sınıfı


### PR DESCRIPTION
## Summary
- Move `fetchExchangeRates` into new `helpers.php`
- Retrieve exchange rates in `quotation_view.php` before guillotine calculations
- Abort save/recalc with clear error when rates cannot be fetched

## Testing
- `php -l helpers.php`
- `php -l test.php`
- `php -l quotation_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68ada5c394388328986424bd156f34f0