### PR TITLE
Merge identical system items in approval and quotation views

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -35,3 +35,46 @@ function fetchExchangeRates(string $base, array $currencies): array
     }
     return $rates;
 }
+
+/**
+ * Returns offer items from guillotine and sliding systems merged by system type and dimensions.
+ *
+ * @param PDO $pdo
+ * @param int $offerId
+ * @return array<int,array{system:string,width:float,height:float,quantity:int,amount:float}>
+ */
+function getOfferSystems(PDO $pdo, int $offerId): array
+{
+    $rows = [];
+    try {
+        $stmt = $pdo->prepare('SELECT system_type AS system, width, height, quantity, total_amount AS amount FROM guillotinesystems WHERE general_offer_id = :id');
+        $stmt->execute([':id' => $offerId]);
+        $rows = array_merge($rows, $stmt->fetchAll());
+    } catch (Exception $e) {
+        // ignore
+    }
+    try {
+        $stmt = $pdo->prepare('SELECT system_type AS system, width, height, quantity, total_amount AS amount FROM slidingsystems WHERE general_offer_id = :id');
+        $stmt->execute([':id' => $offerId]);
+        $rows = array_merge($rows, $stmt->fetchAll());
+    } catch (Exception $e) {
+        // ignore
+    }
+    $merged = [];
+    foreach ($rows as $r) {
+        $key = strtolower((string)$r['system']) . '|' . $r['width'] . '|' . $r['height'];
+        if (!isset($merged[$key])) {
+            $merged[$key] = [
+                'system'   => $r['system'],
+                'width'    => $r['width'],
+                'height'   => $r['height'],
+                'quantity' => (int)$r['quantity'],
+                'amount'   => (float)$r['amount'],
+            ];
+        } else {
+            $merged[$key]['quantity'] += (int)$r['quantity'];
+            $merged[$key]['amount'] += (float)$r['amount'];
+        }
+    }
+    return array_values($merged);
+}

--- a/public/approve.php
+++ b/public/approve.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/../config.php';
+require_once __DIR__ . '/../helpers.php';
 
 function h(?string $v): string
 {
@@ -22,48 +23,9 @@ if (!$offer) {
     exit('Teklif bulunamadı.');
 }
 
-// Fetch related product rows
-$guillotines = [];
-$slidings = [];
-$items = [];
-$totalAmount = 0.0;
-
-try {
-    $gStmt = $pdo->prepare('SELECT system_type, width, height, quantity, total_amount FROM guillotinesystems WHERE general_offer_id = :id');
-    $gStmt->execute([':id' => $offer['id']]);
-    $guillotines = $gStmt->fetchAll(PDO::FETCH_ASSOC);
-} catch (Exception $e) {
-    // ignore
-}
-
-try {
-    $sStmt = $pdo->prepare('SELECT system_type, width, height, quantity, total_amount FROM slidingsystems WHERE general_offer_id = :id');
-    $sStmt->execute([':id' => $offer['id']]);
-    $slidings = $sStmt->fetchAll(PDO::FETCH_ASSOC);
-} catch (Exception $e) {
-    // ignore
-}
-
-foreach ($guillotines as $g) {
-    $items[] = [
-        'system'   => $g['system_type'],
-        'width'    => $g['width'],
-        'height'   => $g['height'],
-        'quantity' => $g['quantity'],
-        'amount'   => $g['total_amount'],
-    ];
-    $totalAmount += (float)$g['total_amount'];
-}
-foreach ($slidings as $s) {
-    $items[] = [
-        'system'   => $s['system_type'],
-        'width'    => $s['width'],
-        'height'   => $s['height'],
-        'quantity' => $s['quantity'],
-        'amount'   => $s['total_amount'],
-    ];
-    $totalAmount += (float)$s['total_amount'];
-}
+// Fetch related product rows merged by size
+$items = getOfferSystems($pdo, (int)$offer['id']);
+$totalAmount = array_reduce($items, fn($carry, $it) => $carry + (float)$it['amount'], 0.0);
 
 $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $offer['status'] === 'pending') {

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -395,13 +395,8 @@ if (!$error) {
     }
 }
 
-$totalAmount = 0;
-foreach ($guillotines as $g) {
-    $totalAmount += (float)$g['total_amount'];
-}
-foreach ($slidings as $s) {
-    $totalAmount += (float)$s['total_amount'];
-}
+$items = getOfferSystems($pdo, $id);
+$totalAmount = array_reduce($items, fn($carry, $it) => $carry + (float)$it['amount'], 0.0);
 $subtotalCalc = round($totalAmount / 1.2, 2);
 $vatAmountCalc = round($totalAmount - $subtotalCalc, 2);
 $totalFormatted = tr_money($totalAmount) . ' ₺';
@@ -539,8 +534,49 @@ page_header('Teklif #' . e((string)$offer['id']), $actions);
                     <span class="fs-5 fw-semibold text-body"><?= e($totalFormatted) ?></span>
                 </div>
             </div>
-        </div>
+</div>
+</div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">Kalemler</h5>
     </div>
+    <?php if ($items): ?>
+    <div class="table-responsive">
+        <table class="table table-sm table-striped mb-0">
+            <thead>
+                <tr>
+                    <th>Sistem Tipi</th>
+                    <th>Ölçüler</th>
+                    <th class="text-end">Adet</th>
+                    <th class="text-end">Tutar</th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($items as $it): ?>
+                <tr>
+                    <td><?= e($it['system']) ?></td>
+                    <td><?= e($it['width'] . ' x ' . $it['height']) ?></td>
+                    <td class="text-end"><?= e((string)$it['quantity']) ?></td>
+                    <td class="text-end"><?= e(tr_money((float)$it['amount'])) ?> ₺</td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th colspan="3" class="text-end">Toplam</th>
+                    <th class="text-end"><?= e(tr_money($totalAmount)) ?> ₺</th>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+    <?php else: ?>
+    <div class="card-body text-center text-secondary">
+        <i class="bi bi-inboxes display-6 mb-2" aria-hidden="true"></i>
+        <p class="mb-0">Kalem bulunamadı.</p>
+    </div>
+    <?php endif; ?>
 </div>
 
 <div class="card mb-4">


### PR DESCRIPTION
## Summary
- add `getOfferSystems` helper to merge guillotine and sliding system entries by size
- use helper in public approval page and quotation view to aggregate identical systems
- display combined system list in quotation view

## Testing
- `php -l helpers.php`
- `php -l public/approve.php`
- `php -l quotation_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68adb29ae71c832885bf407a670818f4