### PR TITLE
fix: resolve logo path check in preview

### DIFF
--- a/pdf/preview.php
+++ b/pdf/preview.php
@@ -268,7 +268,7 @@ if (!empty($quote['offer_date']) && !empty($quote['validity_days'])) {
             <div class="header">
                 <div class="header-left">
                     <div class="logo-container">
-                        <?php if (!empty($company['logo']) && file_exists('../assets/' . $company['logo'])): ?>
+                        <?php if (!empty($company['logo']) && file_exists(__DIR__ . '/../assets/' . $company['logo'])): ?>
                             <img src="../assets/<?= h($company['logo']) ?>" alt="<?= h($company['name']) ?> Logo">
                         <?php else: ?>
                             <div class="logo-placeholder">FİRMA LOGOSU</div>


### PR DESCRIPTION
## Summary
- ensure company logo path check uses absolute path in pdf preview

## Testing
- `php -l pdf/preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68af06631ce88328a6b904456dbe0868