### PR TITLE
Load company-specific settings based on user session

### DIFF
--- a/company.php
+++ b/company.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Fetch company information by ID.
+ *
+ * @param PDO   $pdo       Database connection
+ * @param int   $companyId Company identifier
+ * @return array           Company data or empty array if not found
+ */
+function getCompanyById(PDO $pdo, int $companyId): array
+{
+    if ($companyId <= 0) {
+        return [];
+    }
+
+    try {
+        $stmt = $pdo->prepare('SELECT id, name, email, phone, address, logo FROM company WHERE id = :id');
+        $stmt->execute(['id' => $companyId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: [];
+    } catch (Exception $e) {
+        return [];
+    }
+}

--- a/login.php
+++ b/login.php
@@ -5,6 +5,12 @@ if (session_status() === PHP_SESSION_NONE) {
 require __DIR__ . '/config.php';
 
 $errors = [];
+$hasCompanyColumn = false;
+try {
+    $hasCompanyColumn = $pdo->query("SHOW COLUMNS FROM users LIKE 'company_id'")->rowCount() > 0;
+} catch (Exception $e) {
+    $hasCompanyColumn = false;
+}
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = trim($_POST['username'] ?? '');
@@ -15,13 +21,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     if (!$errors) {
-        $stmt = $pdo->prepare('SELECT id, password FROM users WHERE username = :username AND status = "active"');
+        $sql = 'SELECT id, password' . ($hasCompanyColumn ? ', company_id' : '') . ' FROM users WHERE username = :username AND status = "active"';
+        $stmt = $pdo->prepare($sql);
         $stmt->execute(['username' => $username]);
         $user = $stmt->fetch();
 
         if ($user && password_verify($password, $user['password'])) {
             session_regenerate_id(true);
             $_SESSION['user_id'] = $user['id'];
+            if ($hasCompanyColumn && isset($user['company_id'])) {
+                $_SESSION['company_id'] = (int)$user['company_id'];
+            }
             header('Location: dashboard');
             exit;
         } else {

--- a/quotations.php
+++ b/quotations.php
@@ -192,8 +192,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $action === 'create') {
   if (!$createErrors) {
     try {
       $approvalToken = bin2hex(random_bytes(16));
-      $stmt = $pdo->prepare("INSERT INTO generaloffers (customer_id, offer_date, assembly_type, payment_method, validity_days, installment_term, term_months, interest_value, approval_token) VALUES (:customer_id, :offer_date, :assembly_type, :payment_method, :validity_days, :installment_term, :term_months, :interest_value, :approval_token)");
+      $stmt = $pdo->prepare("INSERT INTO generaloffers (customer_id, company_id, offer_date, assembly_type, payment_method, validity_days, installment_term, term_months, interest_value, approval_token) VALUES (:customer_id, :company_id, :offer_date, :assembly_type, :payment_method, :validity_days, :installment_term, :term_months, :interest_value, :approval_token)");
       $stmt->bindValue(':customer_id', $customerId, PDO::PARAM_INT);
+      $stmt->bindValue(':company_id', $_SESSION['company_id'] ?? null, isset($_SESSION['company_id']) ? PDO::PARAM_INT : PDO::PARAM_NULL);
       $stmt->bindValue(':offer_date', $offerDate);
       $stmt->bindValue(':assembly_type', $assembly);
       $stmt->bindValue(':payment_method', $payment);

--- a/settings.php
+++ b/settings.php
@@ -88,6 +88,17 @@ try {
     $coverColor = '#343a40';
 }
 
+// Fetch company settings for the logged-in user
+$company = [];
+if (!empty($_SESSION['company_id'])) {
+    require_once __DIR__ . '/company.php';
+    try {
+        $company = getCompanyById($pdo, (int)$_SESSION['company_id']);
+    } catch (Exception $e) {
+        $company = [];
+    }
+}
+
 $initial  = strtoupper(substr($user['first_name'] ?? ($user['username'] ?? ''), 0, 1));
 $fullName = trim(($user['first_name'] ?? '') . ' ' . ($user['last_name'] ?? ''));
 
@@ -288,6 +299,23 @@ $acceptRate = $totalOffers > 0 ? round(($acceptedOffers / $totalOffers) * 100) :
                     </div>
                 </div>
             </div>
+            <?php if (!empty($company)): ?>
+            <div class="card mt-3 rounded-3 shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Firma Bilgileri</h5>
+                    <div><strong>Ad:</strong> <?= htmlspecialchars($company['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></div>
+                    <?php if (!empty($company['email'])): ?>
+                        <div><strong>E-posta:</strong> <?= htmlspecialchars($company['email'], ENT_QUOTES, 'UTF-8'); ?></div>
+                    <?php endif; ?>
+                    <?php if (!empty($company['phone'])): ?>
+                        <div><strong>Telefon:</strong> <?= htmlspecialchars($company['phone'], ENT_QUOTES, 'UTF-8'); ?></div>
+                    <?php endif; ?>
+                    <?php if (!empty($company['address'])): ?>
+                        <div><strong>Adres:</strong> <?= nl2br(htmlspecialchars($company['address'], ENT_QUOTES, 'UTF-8')); ?></div>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <?php endif; ?>
         </div>
 
         <div class="tab-pane fade" id="profile-edit" role="tabpanel" aria-labelledby="profile-edit-tab">


### PR DESCRIPTION
## Summary
- add helper to fetch company data by ID
- store company_id in session at login
- include company_id when creating offers
- display logged-in user's company info on settings page

## Testing
- `php -l company.php settings.php login.php quotations.php`


------
https://chatgpt.com/codex/tasks/task_e_68af09db4b248328b104e0bebc67bb51