### PR TITLE
Link company records to user accounts

### DIFF
--- a/company.php
+++ b/company.php
@@ -14,6 +14,8 @@ $csrfToken = $_SESSION['csrf_token'];
 $errors = [];
 $success = '';
 
+$userId = (int)($_SESSION['user_id'] ?? 0);
+
 // Fetch existing company record
 $company = [
     'id' => null,
@@ -25,7 +27,8 @@ $company = [
 ];
 
 try {
-    $stmt = $pdo->query('SELECT id, name, email, phone, address, logo FROM company LIMIT 1');
+    $stmt = $pdo->prepare('SELECT id, name, email, phone, address, logo FROM company WHERE user_id = :uid LIMIT 1');
+    $stmt->execute([':uid' => $userId]);
     if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         $company = array_merge($company, $row);
     }
@@ -82,23 +85,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['company_form'])) {
     if (!$errors) {
         try {
             if ($company['id']) {
-                $stmt = $pdo->prepare('UPDATE company SET name = :name, email = :email, phone = :phone, address = :address, logo = :logo WHERE id = :id');
+                $stmt = $pdo->prepare('UPDATE company SET name = :name, email = :email, phone = :phone, address = :address, logo = :logo WHERE id = :id AND user_id = :uid');
                 $stmt->execute([
                     'name' => $name,
                     'email' => $email,
                     'phone' => $phone,
                     'address' => $address,
                     'logo' => $logoPath,
-                    'id' => $company['id']
+                    'id' => $company['id'],
+                    'uid' => $userId
                 ]);
             } else {
-                $stmt = $pdo->prepare('INSERT INTO company (name, email, phone, address, logo) VALUES (:name, :email, :phone, :address, :logo)');
+                $stmt = $pdo->prepare('INSERT INTO company (name, email, phone, address, logo, user_id) VALUES (:name, :email, :phone, :address, :logo, :uid)');
                 $stmt->execute([
                     'name' => $name,
                     'email' => $email,
                     'phone' => $phone,
                     'address' => $address,
-                    'logo' => $logoPath
+                    'logo' => $logoPath,
+                    'uid' => $userId
                 ]);
                 $company['id'] = (int)$pdo->lastInsertId();
             }

--- a/pdf/preview.php
+++ b/pdf/preview.php
@@ -34,8 +34,8 @@ $error = null;
 $approveUrl = '';
 
 try {
-    $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id WHERE g.id = :id');
-    $stmt->execute([':id' => $id]);
+    $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id WHERE g.id = :id AND co.user_id = :uid');
+    $stmt->execute([':id' => $id, ':uid' => $userId]);
     $quote = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$quote) {
         http_response_code(404);
@@ -52,16 +52,14 @@ try {
 
     $company = ['name' => '', 'logo' => null, 'email' => '', 'phone' => '', 'address' => '', 'bank_account' => ''];
     try {
-        $cStmt = $pdo->query('SELECT name, logo, email, phone, address, bank_account FROM company LIMIT 1');
-        if ($cStmt) {
-            $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
-        }
+        $cStmt = $pdo->prepare('SELECT name, logo, email, phone, address, bank_account FROM company WHERE user_id = :uid LIMIT 1');
+        $cStmt->execute([':uid' => $userId]);
+        $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
     } catch (Throwable $e) {
         try {
-            $cStmt = $pdo->query('SELECT name, logo, email, phone, address FROM company LIMIT 1');
-            if ($cStmt) {
-                $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
-            }
+            $cStmt = $pdo->prepare('SELECT name, logo, email, phone, address FROM company WHERE user_id = :uid LIMIT 1');
+            $cStmt->execute([':uid' => $userId]);
+            $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
         } catch (Throwable $e2) { /* ignore */ }
     }
 

--- a/pdf/preview3.php
+++ b/pdf/preview3.php
@@ -35,8 +35,8 @@ $error = null;
 $approveUrl = '';
 
 try {
-    $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id WHERE g.id = :id');
-    $stmt->execute([':id' => $id]);
+    $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id WHERE g.id = :id AND co.user_id = :uid');
+    $stmt->execute([':id' => $id, ':uid' => $userId]);
     $quote = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$quote) {
         http_response_code(404);
@@ -53,16 +53,14 @@ try {
 
     $company = ['name' => '', 'logo' => null, 'email' => '', 'phone' => '', 'address' => '', 'bank_account' => ''];
     try {
-        $cStmt = $pdo->query('SELECT name, logo, email, phone, address, bank_account FROM company LIMIT 1');
-        if ($cStmt) {
-            $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
-        }
+        $cStmt = $pdo->prepare('SELECT name, logo, email, phone, address, bank_account FROM company WHERE user_id = :uid LIMIT 1');
+        $cStmt->execute([':uid' => $userId]);
+        $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
     } catch (Throwable $e) {
         try {
-            $cStmt = $pdo->query('SELECT name, logo, email, phone, address FROM company LIMIT 1');
-            if ($cStmt) {
-                $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
-            }
+            $cStmt = $pdo->prepare('SELECT name, logo, email, phone, address FROM company WHERE user_id = :uid LIMIT 1');
+            $cStmt->execute([':uid' => $userId]);
+            $company = array_merge($company, $cStmt->fetch(PDO::FETCH_ASSOC) ?: []);
         } catch (Throwable $e2) { /* ignore */
         }
     }

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -35,6 +35,8 @@ if (empty($_SESSION['csrf_token'])) {
 }
 $csrfToken = $_SESSION['csrf_token'];
 
+$userId = (int)($_SESSION['user_id'] ?? 0);
+
 $assemblyTypes = [
     'demonte' => 'Demonte',
     'musteri' => 'Müşteri Montajlı',
@@ -204,9 +206,9 @@ try {
         FROM generaloffers g
         JOIN customers c ON g.customer_id = c.id
         LEFT JOIN company co ON g.company_id = co.id
-        WHERE g.id = :id
+        WHERE g.id = :id AND co.user_id = :uid
     ');
-    $stmt->execute([':id' => $id]);
+    $stmt->execute([':id' => $id, ':uid' => $userId]);
     $offer = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$offer) {
         echo '<div class="container mt-4"><div class="alert alert-danger">Teklif bulunamadı.</div></div></body></html>';

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -55,7 +55,8 @@ CREATE TABLE `company` (
   `name` varchar(255) NOT NULL,
   `email` varchar(255) DEFAULT NULL,
   `phone` varchar(50) DEFAULT NULL,
-  `address` text DEFAULT NULL
+  `address` text DEFAULT NULL,
+  `user_id` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
 -- --------------------------------------------------------
@@ -318,7 +319,8 @@ ALTER TABLE `categories`
 -- Tablo için indeksler `company`
 --
 ALTER TABLE `company`
-  ADD PRIMARY KEY (`id`);
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `user_id` (`user_id`);
 
 --
 -- Tablo için indeksler `customers`
@@ -444,6 +446,12 @@ ALTER TABLE `users`
 --
 -- Dökümü yapılmış tablolar için kısıtlamalar
 --
+
+--
+-- Tablo kısıtlamaları `company`
+--
+ALTER TABLE `company`
+  ADD CONSTRAINT `company_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
 
 --
 -- Tablo kısıtlamaları `generaloffers`


### PR DESCRIPTION
## Summary
- Add `user_id` reference to the `company` table with index and foreign key to `users`
- Scope company CRUD operations and PDF/quotation queries to the logged-in user

## Testing
- `php -l company.php`
- `php -l pdf/preview.php`
- `php -l pdf/preview3.php`
- `php -l quotation_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b00f89ee10832880f42222f66a6cef