### PR TITLE
Log company save errors

### DIFF
--- a/company.php
+++ b/company.php
@@ -114,7 +114,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['company_form'])) {
             $company['logo'] = $logoPath;
             $success = 'Şirket bilgileri güncellendi.';
         } catch (Exception $e) {
-            $errors['general'] = 'Bilgiler kaydedilemedi.';
+            error_log('Company save failed [' . $e->getCode() . ']: ' . $e->getMessage());
+            $errors['general'] = 'Şirket bilgileri kaydedilemedi. Lütfen daha sonra tekrar deneyin.';
         }
     }
 }


### PR DESCRIPTION
## Summary
- log database errors when saving company and provide clearer message for users

## Testing
- `php -l company.php`


------
https://chatgpt.com/codex/tasks/task_e_68b011f66708832887cebd25aa01a669