### PR TITLE
Improve quotation and PDF preview queries and error messages

### DIFF
--- a/pdf/preview.php
+++ b/pdf/preview.php
@@ -23,7 +23,7 @@ $userId = (int)$_SESSION['user_id'];
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
 if (!$id) {
     http_response_code(400);
-    exit('Geçersiz istek');
+    exit('Geçersiz teklif ID\'si. <a href="../quotations.php">Teklif listesine dön</a>.');
 }
 
 $quote = null;
@@ -34,12 +34,12 @@ $error = null;
 $approveUrl = '';
 
 try {
-    $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id WHERE g.id = :id AND co.user_id = :uid');
+    $stmt = $pdo->prepare('SELECT g.*, c.first_name, c.last_name, c.company_name AS customer_company, c.email AS customer_email, c.phone AS customer_phone, c.address AS customer_address, co.name AS company_name FROM generaloffers g LEFT JOIN customers c ON g.customer_id = c.id LEFT JOIN company co ON g.company_id = co.id AND co.user_id = :uid WHERE g.id = :id AND (g.company_id IS NULL OR co.id IS NOT NULL)');
     $stmt->execute([':id' => $id, ':uid' => $userId]);
     $quote = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$quote) {
         http_response_code(404);
-        exit('Teklif bulunamadı');
+        exit('Teklif bulunamadı veya erişim yetkiniz yok. <a href="../quotations.php">Teklif listesine dön</a>.');
     }
 
     $gStmt = $pdo->prepare('SELECT system_type, width, height, quantity, motor_system, ral_code, glass_type, glass_color, total_amount FROM guillotinesystems WHERE general_offer_id = :id');

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -67,7 +67,7 @@ $statusClasses = [
 ];
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
 if (!$id) {
-    echo '<div class="container mt-4"><div class="alert alert-danger">Teklif bulunamadı.</div></div></body></html>';
+    echo '<div class="container mt-4"><div class="alert alert-danger">Geçersiz teklif ID\'si. <a href="quotations.php">Teklif listesine dön</a>.</div></div></body></html>';
     exit;
 }
 
@@ -205,13 +205,13 @@ try {
         SELECT g.*, c.first_name, c.last_name, c.company AS customer_company, co.name AS company_name
         FROM generaloffers g
         JOIN customers c ON g.customer_id = c.id
-        LEFT JOIN company co ON g.company_id = co.id
-        WHERE g.id = :id AND co.user_id = :uid
+        LEFT JOIN company co ON g.company_id = co.id AND co.user_id = :uid
+        WHERE g.id = :id AND (g.company_id IS NULL OR co.id IS NOT NULL)
     ');
     $stmt->execute([':id' => $id, ':uid' => $userId]);
     $offer = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$offer) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Teklif bulunamadı.</div></div></body></html>';
+        echo '<div class="container mt-4"><div class="alert alert-danger">Teklif bulunamadı veya erişim yetkiniz yok. <a href="quotations.php">Teklif listesine dön</a>.</div></div></body></html>';
         exit;
     }
 } catch (Exception $e) {
@@ -220,7 +220,7 @@ try {
 }
 
 if (!$offer) {
-    echo '<div class="container mt-4"><div class="alert alert-danger">' . e($error) . '</div></div></body></html>';
+    echo '<div class="container mt-4"><div class="alert alert-danger">' . e($error) . ' <a href="quotations.php">Teklif listesine dön</a>.</div></div></body></html>';
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Allow viewing quotations without company info by moving user filter into LEFT JOIN
- Show clearer messages when id is missing or quotation not found
- Apply the same fixes to PDF preview

## Testing
- `php -l quotation_view.php`
- `php -l pdf/preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68b013c750b88328adf627c7522b95c2