### PR TITLE
Gracefully handle exchange rate API failures

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,6 +7,12 @@ const DB_NAME = 'teklifpro';
 const DB_USER = 'root';
 const DB_PASS = '';
 
+// Local fallback exchange rates used if the external API fails.
+const LOCAL_EXCHANGE_RATES = [
+    'USD' => 30.0,
+    'EUR' => 32.0,
+];
+
 try {
     $pdo = new PDO(
         'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4',

--- a/helpers.php
+++ b/helpers.php
@@ -11,15 +11,18 @@ declare(strict_types=1);
  * @param string $base       Base currency code.
  * @param array  $currencies Target currency codes.
  *
- * @return array<string,float>
+ * @return array<string,float>|null Returns null if rates couldn't be fetched.
  */
-function fetchExchangeRates(string $base, array $currencies): array
+function fetchExchangeRates(string $base, array $currencies): ?array
 {
     $base = strtoupper($base);
     $json = @file_get_contents("https://open.er-api.com/v6/latest/{$base}");
-    $data = $json ? json_decode($json, true) : null;
+    if ($json === false) {
+        throw new RuntimeException('Exchange rate API request failed.');
+    }
+    $data = json_decode($json, true);
     if (!is_array($data) || (($data['result'] ?? '') !== 'success') || empty($data['rates'])) {
-        return [];
+        throw new RuntimeException('Invalid exchange rate API response.');
     }
     $rates = [];
     foreach ($currencies as $cur) {
@@ -33,5 +36,5 @@ function fetchExchangeRates(string $base, array $currencies): array
             $rates[$curUpper] = 1 / $rate;
         }
     }
-    return $rates;
+    return $rates ?: null;
 }

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -194,7 +194,16 @@ if (
             if ((float)($row['width'] ?? 0) <= 0 || (float)($row['height'] ?? 0) <= 0 || (int)($row['quantity'] ?? 0) <= 0) {
                 throw new Exception('Geçersiz giyotin satırı.');
             }
-            $exchangeRates = fetchExchangeRates('TRY', ['USD', 'EUR']);
+            $exchangeSource = 'API';
+            try {
+                $exchangeRates = fetchExchangeRates('TRY', ['USD', 'EUR']);
+            } catch (Throwable $e) {
+                $exchangeRates = null;
+            }
+            if (empty($exchangeRates)) {
+                $exchangeRates = array_change_key_case(LOCAL_EXCHANGE_RATES ?? [], CASE_UPPER);
+                $exchangeSource = empty($exchangeRates) ? $exchangeSource : 'local';
+            }
             if (empty($exchangeRates)) {
                 if ($pdo->inTransaction()) {
                     $pdo->rollBack();
@@ -203,6 +212,7 @@ if (
                 echo json_encode(['error' => 'Kur bilgileri alınamadı.']);
                 exit;
             }
+            error_log('Exchange rates source: ' . $exchangeSource . ' ' . json_encode($exchangeRates));
             $totals = calculateGuillotineTotals([
                 'width'         => $row['width'],
                 'height'        => $row['height'],
@@ -232,7 +242,11 @@ if (
 
             $pdo->commit();
             header('Content-Type: application/json');
-            echo json_encode(['success' => true]);
+            echo json_encode([
+                'success' => true,
+                'exchange_rates' => $exchangeRates,
+                'exchange_source' => $exchangeSource,
+            ]);
             exit;
         } else {
             throw new Exception('Giyotin satırı bulunamadı.');
@@ -343,10 +357,20 @@ if ($gPost) {
             if (!$validNumbers) {
                 $error = 'Tüm sayısal alanlar pozitif olmalıdır.';
             } else {
-                $exchangeRates = fetchExchangeRates('TRY', ['USD', 'EUR']);
+                $exchangeSource = 'API';
+                try {
+                    $exchangeRates = fetchExchangeRates('TRY', ['USD', 'EUR']);
+                } catch (Throwable $e) {
+                    $exchangeRates = null;
+                }
+                if (empty($exchangeRates)) {
+                    $exchangeRates = array_change_key_case(LOCAL_EXCHANGE_RATES ?? [], CASE_UPPER);
+                    $exchangeSource = empty($exchangeRates) ? $exchangeSource : 'local';
+                }
                 if (empty($exchangeRates)) {
                     $error = 'Kur bilgileri alınamadı.';
                 } else {
+                    error_log('Exchange rates source: ' . $exchangeSource . ' ' . json_encode($exchangeRates));
                     if ($gId) {
                         $sql = 'UPDATE guillotinesystems SET width=:width, height=:height, quantity=:quantity, motor_system=:motor, remote_quantity=:remote, ral_code=:ral, glass_type=:glass_type, glass_color=:glass_color, profit_margin=:profit_margin WHERE id=:id AND general_offer_id=:goid';
                         $params = [
@@ -415,7 +439,8 @@ if ($gPost) {
                     $overall = $gSum + $sSum;
                     $updStmt = $pdo->prepare('UPDATE generaloffers SET total_amount = :total WHERE id = :id');
                     $updStmt->execute([':total' => $overall, ':id' => $id]);
-                    $success = $gId ? 'Giyotin sistemi güncellendi.' : 'Giyotin sistemi eklendi.';
+                    $success = ($gId ? 'Giyotin sistemi güncellendi.' : 'Giyotin sistemi eklendi.')
+                        . ' (Kur kaynağı: ' . ($exchangeSource === 'API' ? 'API' : 'Yerel') . ')';
                 }
             }
         } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- Throw on failed exchange-rate API calls and return `null` when no data
- Use local fallback exchange rates in quotation view when API fails
- Inform users/log about currency rate source (API or local)

## Testing
- `php -l helpers.php`
- `php -l config.php`
- `php -l quotation_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b195d332f48328afde0252e84112af