### PR TITLE
Track shared offers and auto-progress drafts

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -79,13 +79,13 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.share-btn').forEach(btn => {
     btn.addEventListener('click', async () => {
       const url = btn.getAttribute('data-url');
+      const offerId = btn.getAttribute('data-offer-id');
+      const token = btn.getAttribute('data-csrf');
       if (!url) return;
+      btn.disabled = true;
+      btn.setAttribute('aria-busy', 'true');
       if (navigator.share) {
-        try {
-          await navigator.share({ url });
-        } catch (e) {
-          /* ignore */
-        }
+        try { await navigator.share({ url }); } catch (e) { /* ignore */ }
       } else {
         try {
           await navigator.clipboard.writeText(url);
@@ -94,6 +94,38 @@ document.addEventListener('DOMContentLoaded', () => {
           window.showToast && window.showToast('Bağlantı kopyalanamadı', 'danger');
         }
       }
+      if (offerId && token) {
+        try {
+          const fd = new FormData();
+          fd.append('csrf_token', token);
+          fd.append('id', offerId);
+          const res = await fetch(`/offers/${offerId}/mark-shared`, { method: 'POST', body: fd });
+          if (res.ok) {
+            const data = await res.json();
+            const status = data.status;
+            const scount = data.share_count;
+            if (window.isAdmin) {
+              const sel = document.getElementById('statusSelect');
+              sel && (sel.value = status);
+            } else {
+              const badge = document.getElementById('statusBadge');
+              if (badge && window.statusLabels && window.statusClasses) {
+                badge.textContent = window.statusLabels[status] || status;
+                badge.className = `badge bg-${window.statusClasses[status] || 'secondary'}`;
+              }
+            }
+            const scEl = document.getElementById('shareCount');
+            scEl && (scEl.textContent = scount);
+            window.showToast && window.showToast('Teklif paylaşıldı ve durum Devam Ediyor olarak güncellendi.', 'success');
+          } else {
+            window.showToast && window.showToast('Paylaşım kaydı oluşturulamadı', 'danger');
+          }
+        } catch (e) {
+          window.showToast && window.showToast('Paylaşım kaydı oluşturulamadı', 'danger');
+        }
+      }
+      btn.removeAttribute('aria-busy');
+      btn.disabled = false;
     });
   });
 });

--- a/config.php
+++ b/config.php
@@ -31,6 +31,16 @@ try {
     // Ignore if the table is missing
 }
 
+// Schema adjustments for share tracking
+try {
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS shared_at DATETIME NULL");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS shared_by INT NULL");
+    $pdo->exec("ALTER TABLE generaloffers ADD COLUMN IF NOT EXISTS share_count INT NOT NULL DEFAULT 0");
+    $pdo->exec("ALTER TABLE generaloffers ADD INDEX IF NOT EXISTS idx_generaloffers_shared_by (shared_by)");
+    $pdo->exec("ALTER TABLE generaloffers ADD CONSTRAINT IF NOT EXISTS fk_generaloffers_shared_by FOREIGN KEY (shared_by) REFERENCES users(id)");
+} catch (Exception $e) {
+}
+
 // Populate missing valid_until values
 try {
     $pdo->exec(

--- a/footer.php
+++ b/footer.php
@@ -3,7 +3,7 @@
     &copy; <?= date('Y'); ?> TeklifPro
   </footer>
 
-  <div id="toastContainer" class="toast-container position-fixed bottom-0 end-0 p-3"></div>
+  <div id="toastContainer" class="toast-container position-fixed top-0 end-0 p-3"></div>
 
   <div class="modal fade" id="confirmModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">

--- a/mark_shared_service.php
+++ b/mark_shared_service.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+function mark_offer_shared(PDO $pdo, int $offerId, int $userId): array|false
+{
+    try {
+        $pdo->beginTransaction();
+        $forUpdate = ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') ? ' FOR UPDATE' : '';
+        $stmt = $pdo->prepare('SELECT status, share_count FROM generaloffers WHERE id = :id' . $forUpdate);
+        $stmt->execute([':id' => $offerId]);
+        $offer = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$offer) {
+            $pdo->rollBack();
+            return false;
+        }
+        $status = ($offer['status'] === 'draft') ? 'in_progress' : $offer['status'];
+        $upd = $pdo->prepare('UPDATE generaloffers SET status = :st, share_count = share_count + 1, shared_at = CURRENT_TIMESTAMP, shared_by = :uid WHERE id = :id');
+        $upd->execute([':st' => $status, ':uid' => $userId, ':id' => $offerId]);
+        $pdo->commit();
+        return ['status' => $status, 'share_count' => (int)$offer['share_count'] + 1];
+    } catch (Exception $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        return false;
+    }
+}

--- a/offers/mark_shared.php
+++ b/offers/mark_shared.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!isset($pdo)) {
+    require_once __DIR__ . '/../config.php';
+}
+require_once __DIR__ . '/../mark_shared_service.php';
+
+if (PHP_SAPI !== 'cli') {
+    header('Content-Type: application/json');
+}
+$GLOBALS['response_code'] = 200;
+
+$token = $_POST['csrf_token'] ?? '';
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+    $GLOBALS['response_code'] = 400;
+    @http_response_code(400);
+    echo json_encode(['error' => 'Geçersiz CSRF tokenı.']);
+    if (PHP_SAPI !== 'cli') {
+        exit;
+    }
+    return;
+}
+
+$userId = (int)($_SESSION['user_id'] ?? 0);
+if (!$userId) {
+    $GLOBALS['response_code'] = 403;
+    @http_response_code(403);
+    echo json_encode(['error' => 'Yetki yok.']);
+    if (PHP_SAPI !== 'cli') {
+        exit;
+    }
+    return;
+}
+
+$id = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+if (!$id && isset($_SERVER['REQUEST_URI'])) {
+    if (preg_match('#/offers/(\d+)/mark-shared#', $_SERVER['REQUEST_URI'], $m)) {
+        $id = (int)$m[1];
+    }
+}
+if (!$id) {
+    $GLOBALS['response_code'] = 400;
+    @http_response_code(400);
+    echo json_encode(['error' => 'Geçersiz teklif ID.']);
+    if (PHP_SAPI !== 'cli') {
+        exit;
+    }
+    return;
+}
+
+$stmt = $pdo->prepare('SELECT r.name FROM users u JOIN roles r ON u.role_id = r.id WHERE u.id = :id');
+$stmt->execute([':id' => $userId]);
+$role = $stmt->fetchColumn() ?: 'user';
+
+$perm = $pdo->prepare('SELECT g.id FROM generaloffers g LEFT JOIN company c ON g.company_id = c.id WHERE g.id = :id AND (:admin OR g.company_id IS NULL OR c.user_id = :uid)');
+$perm->execute([':id' => $id, ':uid' => $userId, ':admin' => $role === 'admin' ? 1 : 0]);
+if (!$perm->fetchColumn()) {
+    $GLOBALS['response_code'] = 403;
+    @http_response_code(403);
+    echo json_encode(['error' => 'Yetki yok.']);
+    if (PHP_SAPI !== 'cli') {
+        exit;
+    }
+    return;
+}
+
+$result = mark_offer_shared($pdo, $id, $userId);
+if ($result === false) {
+    $GLOBALS['response_code'] = 400;
+    @http_response_code(400);
+    echo json_encode(['error' => 'Paylaşım kaydı oluşturulamadı.']);
+    if (PHP_SAPI !== 'cli') {
+        exit;
+    }
+    return;
+}
+
+echo json_encode(['success' => true, 'status' => $result['status'], 'share_count' => $result['share_count']]);

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -552,7 +552,12 @@ page_header($title, $actions, true);
                 <?php if ($approveUrl): ?>
                     <div class="mb-2">
                         <span class="text-muted small d-block">Onay Linki</span>
-                        <button type="button" class="btn btn-sm btn-outline-secondary share-btn offer-action" data-url="<?= e($approveUrl) ?>">
+                        <button
+                            type="button"
+                            class="btn btn-sm btn-outline-secondary share-btn offer-action"
+                            data-url="<?= e($approveUrl) ?>"
+                            data-offer-id="<?= e((string)$offer['id']) ?>"
+                            data-csrf="<?= e($csrfToken) ?>">
                             <i class="bi bi-share me-1" aria-hidden="true"></i><span class="visually-hidden">Bağlantıyı kopyala</span> Paylaş
                         </button>
                     </div>
@@ -573,7 +578,7 @@ page_header($title, $actions, true);
                         </form>
                     <?php else: ?>
                         <span class="text-muted small d-block">Durum</span>
-                        <span class="badge bg-<?= e($statusClasses[$offer['status']] ?? 'secondary') ?>"><?= e($statusLabels[$offer['status']] ?? $offer['status']) ?></span>
+                        <span id="statusBadge" class="badge bg-<?= e($statusClasses[$offer['status']] ?? 'secondary') ?>"><?= e($statusLabels[$offer['status']] ?? $offer['status']) ?></span>
                     <?php endif; ?>
                 </div>
             </div>
@@ -952,6 +957,11 @@ page_header($title, $actions, true);
   </div>
 </div>
 <?php endif; ?>
+<script>
+window.statusLabels = <?= json_encode($statusLabels, JSON_UNESCAPED_UNICODE) ?>;
+window.statusClasses = <?= json_encode($statusClasses, JSON_UNESCAPED_UNICODE) ?>;
+window.isAdmin = <?= $role === 'admin' ? 'true' : 'false' ?>;
+</script>
 <script>
 const offerExpired = <?= $expired ? 'true' : 'false' ?>;
 if (offerExpired) {

--- a/teklifpro.sql
+++ b/teklifpro.sql
@@ -127,18 +127,21 @@ CREATE TABLE `generaloffers` (
   `status` varchar(20) NOT NULL DEFAULT 'pending',
   `approval_token` varchar(64) DEFAULT NULL,
   `approved_at` datetime DEFAULT NULL,
-  `note` text DEFAULT NULL
+  `note` text DEFAULT NULL,
+  `shared_at` datetime DEFAULT NULL,
+  `shared_by` int(11) DEFAULT NULL,
+  `share_count` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
 --
 -- Tablo döküm verisi `generaloffers`
 --
 
-INSERT INTO `generaloffers` (`id`, `quote_no`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `validity_days`, `installment_term`, `payment_type`, `term_months`, `interest_mode`, `interest_value`, `interest_amount`, `total_with_interest`, `monthly_installment`, `grace_days`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`, `profit_percent`, `profit_amount`, `status`, `approval_token`, `approved_at`, `note`) VALUES
-(11, NULL, 1, NULL, '2025-08-22', 'demonte', NULL, 'cash', 10, NULL, 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6761.20, NULL, NULL, 'sent', '6a11fec84c4615436d2015e24e35e184', '2025-08-23 08:36:37', NULL),
-(13, NULL, 2, NULL, '2025-08-25', 'demonte', NULL, 'vadeli', 10, NULL, 'cash', 1, NULL, 5.00, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00, NULL, NULL, 'accepted', NULL, '2025-08-26 08:58:43', NULL),
-(14, NULL, 1, NULL, '2025-08-26', 'demonte', NULL, 'cash', 10, NULL, 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 13665.28, NULL, NULL, 'draft', NULL, '2025-08-26 15:31:44', NULL),
-(15, NULL, 2, NULL, '2025-08-26', 'demonte', NULL, 'cash', NULL, NULL, 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 95607.96, NULL, NULL, 'pending', '2ee79016512d3738b795028bb3593a6e', NULL, NULL);
+INSERT INTO `generaloffers` (`id`, `quote_no`, `customer_id`, `company_id`, `offer_date`, `assembly_type`, `delivery_time`, `payment_method`, `validity_days`, `installment_term`, `payment_type`, `term_months`, `interest_mode`, `interest_value`, `interest_amount`, `total_with_interest`, `monthly_installment`, `grace_days`, `payment_term`, `offer_validity`, `maturity_period`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `total_amount`, `profit_percent`, `profit_amount`, `status`, `approval_token`, `approved_at`, `note`, `shared_at`, `shared_by`, `share_count`) VALUES
+(11, NULL, 1, NULL, '2025-08-22', 'demonte', NULL, 'cash', 10, NULL, 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6761.20, NULL, NULL, 'sent', '6a11fec84c4615436d2015e24e35e184', '2025-08-23 08:36:37', NULL, NULL, NULL, 0),
+(13, NULL, 2, NULL, '2025-08-25', 'demonte', NULL, 'vadeli', 10, NULL, 'cash', 1, NULL, 5.00, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.00, NULL, NULL, 'accepted', NULL, '2025-08-26 08:58:43', NULL, NULL, NULL, 0),
+(14, NULL, 1, NULL, '2025-08-26', 'demonte', NULL, 'cash', 10, NULL, 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 13665.28, NULL, NULL, 'draft', NULL, '2025-08-26 15:31:44', NULL, NULL, NULL, 0),
+(15, NULL, 2, NULL, '2025-08-26', 'demonte', NULL, 'cash', NULL, NULL, 'cash', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 95607.96, NULL, NULL, 'pending', '2ee79016512d3738b795028bb3593a6e', NULL, NULL, NULL, 0);
 
 -- --------------------------------------------------------
 
@@ -365,7 +368,8 @@ ALTER TABLE `generaloffers`
   ADD PRIMARY KEY (`id`),
   ADD KEY `customer_id` (`customer_id`),
   ADD KEY `company_id` (`company_id`),
-  ADD KEY `idx_generaloffers_status` (`status`);
+  ADD KEY `idx_generaloffers_status` (`status`),
+  ADD KEY `idx_generaloffers_shared_by` (`shared_by`);
 
 --
 -- Tablo için indeksler `guillotinesystems`
@@ -482,7 +486,8 @@ ALTER TABLE `users`
 --
 ALTER TABLE `generaloffers`
   ADD CONSTRAINT `generaloffers_ibfk_1` FOREIGN KEY (`customer_id`) REFERENCES `customers` (`id`),
-  ADD CONSTRAINT `generaloffers_ibfk_2` FOREIGN KEY (`company_id`) REFERENCES `company` (`id`);
+  ADD CONSTRAINT `generaloffers_ibfk_2` FOREIGN KEY (`company_id`) REFERENCES `company` (`id`),
+  ADD CONSTRAINT `generaloffers_ibfk_3` FOREIGN KEY (`shared_by`) REFERENCES `users` (`id`);
 
 --
 -- Tablo kısıtlamaları `products`

--- a/tests/MarkSharedOfferTest.php
+++ b/tests/MarkSharedOfferTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../mark_shared_service.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+final class MarkSharedOfferTest extends TestCase
+{
+    private function createPdo(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE generaloffers (id INTEGER PRIMARY KEY, status TEXT, share_count INT DEFAULT 0, shared_at DATETIME NULL, shared_by INT NULL)');
+        return $pdo;
+    }
+
+    public function testDraftMovesToInProgress(): void
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec("INSERT INTO generaloffers (id, status, share_count) VALUES (1, 'draft', 0)");
+        $res = mark_offer_shared($pdo, 1, 5);
+        $this->assertEquals('in_progress', $res['status']);
+        $this->assertEquals(1, $res['share_count']);
+        $row = $pdo->query('SELECT status, share_count, shared_by FROM generaloffers WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertEquals('in_progress', $row['status']);
+        $this->assertEquals(1, $row['share_count']);
+        $this->assertEquals(5, $row['shared_by']);
+    }
+
+    public function testApprovedStatusUnaffected(): void
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec("INSERT INTO generaloffers (id, status, share_count) VALUES (1, 'approved', 2)");
+        $res = mark_offer_shared($pdo, 1, 7);
+        $this->assertEquals('approved', $res['status']);
+        $this->assertEquals(3, $res['share_count']);
+        $row = $pdo->query('SELECT status, share_count FROM generaloffers WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertEquals('approved', $row['status']);
+        $this->assertEquals(3, $row['share_count']);
+    }
+
+    public function testCsrfFailureReturns400(): void
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec("INSERT INTO generaloffers (id, status, share_count) VALUES (1, 'draft', 0)");
+        $_SESSION['csrf_token'] = 'token';
+        $_SESSION['user_id'] = 1;
+        $_POST = ['csrf_token' => 'wrong', 'id' => 1];
+        $_SERVER['REQUEST_URI'] = '/offers/1/mark-shared';
+        ob_start();
+        include __DIR__ . '/../offers/mark_shared.php';
+        ob_end_clean();
+        $this->assertSame(400, $GLOBALS['response_code']);
+    }
+}


### PR DESCRIPTION
## Summary
- Track offer sharing time, user, and count on `generaloffers`
- Add `/offers/{id}/mark-shared` endpoint to bump share count and move drafts to in_progress
- Update share button to call backend, adjust status UI, and show toast
- Add unit tests for draft progression, status stability, and CSRF rejection

## Testing
- `phpunit tests/MarkSharedOfferTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b55467fedc83289952c23098095c7d