### PR TITLE
Use product_code in PdoProductProvider queries

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -16,7 +16,7 @@ class PdoProductProvider implements ProductProviderInterface
     public function getProduct(string $name): ?array
     {
         $stmt = $this->pdo->prepare(
-            'SELECT p.unit, p.unit_price, p.vat_rate, p.weight_per_meter, p.price_unit, c.name AS category '
+            'SELECT p.product_code AS code, p.unit, p.unit_price, p.vat_rate, p.weight_per_meter, p.price_unit, c.name AS category '
                 . 'FROM products p LEFT JOIN categories c ON p.category_id = c.id '
                 . 'WHERE LOWER(p.name) = LOWER(:name)'
         );

--- a/test.php
+++ b/test.php
@@ -477,7 +477,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
         //
         public function getProduct(string $name): ?array
         {
-            $stmt = $this->pdo->prepare('SELECT p.unit, p.unit_price, p.weight_per_meter, p.price_unit, c.name AS category FROM products p LEFT JOIN categories c ON p.category_id = c.id WHERE LOWER(p.name) = LOWER(:name)');
+            $stmt = $this->pdo->prepare('SELECT p.product_code AS code, p.unit, p.unit_price, p.weight_per_meter, p.price_unit, c.name AS category FROM products p LEFT JOIN categories c ON p.category_id = c.id WHERE LOWER(p.name) = LOWER(:name)');
             $stmt->execute([':name' => $name]);
 
             $row = $stmt->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- Include `product_code` as `code` when fetching product data in `PdoProductProvider`
- Align product queries in `quotation_view.php` and `test.php` with updated schema

## Testing
- `php -l test.php`
- `php -l quotation_view.php`
- `php -l optimazsyon.php`
- `phpunit tests/ReactivateOfferTest.php`
- `php /tmp/run_query.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5a99c4bb083288328fb8fcbced5ab