### PR TITLE
Show system details on optimization page

### DIFF
--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -510,7 +510,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     // Giyotin Verileri
     // Veritabanından ilgili ölçü ve ayarları çeker.
     //
-    $stmt = $pdo->prepare('SELECT width, height, quantity, glass_type, motor_system, remote_quantity, profit_margin, general_offer_id FROM guillotinesystems WHERE id = :id');
+    $stmt = $pdo->prepare('SELECT width, height, quantity, glass_type, glass_color, motor_system, remote_quantity, ral_code, profit_margin, general_offer_id FROM guillotinesystems WHERE id = :id');
     $stmt->execute([':id' => $id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$row) {
@@ -590,6 +590,22 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     }
     echo '<h2 class="h5 fw-bold mb-0">GİYOTİN SİSTEMİ</h2>';
     echo '</div>';
+
+    $infoRows = [
+        'Sistem Genişliği'  => number_format((float) $row['width'], 0, ',', '.'),
+        'Sistem Yüksekliği' => number_format((float) $row['height'], 0, ',', '.'),
+        'Adet'              => number_format((int) $row['quantity'], 0, ',', '.'),
+        'Kumanda Adedi'     => number_format((int) ($row['remote_quantity'] ?? 0), 0, ',', '.'),
+        'Motor Markası'     => $row['motor_system'] ?? '',
+        'RAL Kodu'          => $row['ral_code'] ?? '',
+        'Cam Kombinasyonu'  => $row['glass_type'] ?? '',
+        'Cam Rengi'         => $row['glass_color'] ?? '',
+    ];
+    echo '<div class="container mb-4"><table class="table table-bordered table-sm w-auto mx-auto"><tbody>';
+    foreach ($infoRows as $label => $value) {
+        echo '<tr><th>' . e($label) . '</th><td>' . e((string) $value) . '</td></tr>';
+    }
+    echo '</tbody></table></div>';
 
     echo '<div class="product-grid">';
     foreach ($lines as $line) {

--- a/quotation_view.php
+++ b/quotation_view.php
@@ -654,7 +654,7 @@ page_header($title, $actions, true);
                                                 </a>
                                             </li>
                                             <li>
-                                                <a href="optimazsyon.php?quote_id=<?= e((string)$g['id']) ?>" class="dropdown-item">
+                                                <a href="optimizasyon.php?quote_id=<?= e((string)$g['id']) ?>" class="dropdown-item">
                                                     <i class="bi bi-gear me-1"></i> Optimizasyon
                                                 </a>
                                             </li>


### PR DESCRIPTION
## Summary
- rename optimazsyon.php to optimizasyon.php and update link usage
- display system width, height, quantities, motor brand, RAL code, glass combination and color on optimization view

## Testing
- `php -l optimizasyon.php`
- `php -l quotation_view.php`
- `phpunit tests/ReactivateOfferTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6a426d2b8832899c0d815100f7ac1