### PR TITLE
Display guillotine system details in optimization view

### DIFF
--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -510,7 +510,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     // Giyotin Verileri
     // Veritabanından ilgili ölçü ve ayarları çeker.
     //
-    $stmt = $pdo->prepare('SELECT width, height, quantity, glass_type, motor_system, remote_quantity, profit_margin, general_offer_id FROM guillotinesystems WHERE id = :id');
+    $stmt = $pdo->prepare('SELECT width, height, quantity, glass_type, glass_color, motor_system, remote_quantity, ral_code, profit_margin, general_offer_id FROM guillotinesystems WHERE id = :id');
     $stmt->execute([':id' => $id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$row) {
@@ -590,6 +590,22 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     }
     echo '<h2 class="h5 fw-bold mb-0">GİYOTİN SİSTEMİ</h2>';
     echo '</div>';
+
+    $infoRows = [
+        'Sistem Genişliği'  => number_format((float)($row['width'] ?? 0), 0, ',', '.'),
+        'Sistem Yüksekliği' => number_format((float)($row['height'] ?? 0), 0, ',', '.'),
+        'Adet'              => number_format((int)($row['quantity'] ?? 0), 0, ',', '.'),
+        'Kumanda Adedi'     => number_format((int)($row['remote_quantity'] ?? 0), 0, ',', '.'),
+        'Motor Markası'     => (string)($row['motor_system'] ?? ''),
+        'Ral Kodu'          => (string)($row['ral_code'] ?? ''),
+        'Cam Kombinasyonu'  => (string)($row['glass_type'] ?? ''),
+        'Cam Rengi'         => (string)($row['glass_color'] ?? ''),
+    ];
+    echo '<div class="table-responsive mb-3"><table class="table table-bordered table-sm w-auto mx-auto"><tbody>';
+    foreach ($infoRows as $label => $value) {
+        echo '<tr><th>' . e($label) . '</th><td>' . e($value) . '</td></tr>';
+    }
+    echo '</tbody></table></div>';
 
     echo '<div class="product-grid">';
     foreach ($lines as $line) {


### PR DESCRIPTION
## Summary
- Include system width, height, quantity, remote count, motor brand, RAL code, glass combination and color in `optimizasyon.php`
- Fetch additional fields from database and render summary table before product grid

## Testing
- `php -l optimizasyon.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a5e2ba2083288510b04594044800