### PR TITLE
Stop redirecting optimization page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ RewriteEngine On
 RewriteBase /
 
 # Redirect legacy optimization page to new endpoint
-RewriteRule ^optimizasyon(\.php)?$ guillotine_optimize_view [R=301,L]
+#RewriteRule ^optimizasyon(\.php)?$ guillotine_optimize_view [R=301,L]
 
 # 1) Hata sayfalarına ve fiziksel varlıklara dokunma (loop'u kes)
 RewriteCond %{REQUEST_URI} ^/errors/ [OR]


### PR DESCRIPTION
## Summary
- Disable .htaccess rule that redirected `optimizasyon.php` to `guillotine_optimize_view`

## Testing
- `phpunit --version` *(command not found)*
- `php tests/ReactivateOfferTest.php` *(PHPUnit framework missing)*
- `php -l optimizasyon.php`
- `service apache2 reload` *(apache2: unrecognized service)*
- `curl -I http://127.0.0.1:8080/optimizasyon.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6abfa578c8328bc06d720dba3cb21