### PR TITLE
Sync sales total on edit

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -929,8 +929,19 @@ page_header($title, $actions, true);
                 window.showToast && window.showToast('Hesaplama sırasında sorun oluştu, sayfa açılıyor…', 'warning');
             }
             window.location.href = url;
+        });
     });
-});
+
+    document.querySelectorAll('.edit-guillotine').forEach(function(btn) {
+        btn.addEventListener('click', async function() {
+            const gid = this.getAttribute('data-id');
+            try {
+                await fetch('test.php?quote_id=' + encodeURIComponent(gid) + '&format=json');
+            } catch (err) {
+                console.error(err);
+            }
+        });
+    });
 </script>
 <?php if ($expired): ?>
 <div class="modal fade" id="reactivateModal" tabindex="-1" aria-hidden="true">

--- a/test.php
+++ b/test.php
@@ -677,6 +677,12 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $offerUpd = $pdo->prepare('UPDATE generaloffers SET total_amount = :t WHERE id = :id');
     $offerUpd->execute([':t' => $gSum + $sSum, ':id' => $row['general_offer_id']]);
 
+    if (($_GET['format'] ?? '') === 'json') {
+        header('Content-Type: application/json');
+        echo json_encode(['sales_total' => $salesTotal]);
+        exit;
+    }
+
     //
     // Kategori Döngüsü
     // Her kategori için tablo oluşturarak satırları listeler.


### PR DESCRIPTION
## Summary
- Expose a JSON response in `test.php` so sales totals can be updated programmatically
- Trigger a background call to `test.php` when editing a guillotine to keep the sales amount synced with the quotation

## Testing
- `php -l test.php`
- `php -l quotation_view.php`
- `php tests/ReactivateOfferTest.php` *(fails: Class "PHPUnit\\Framework\\TestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e07e2dd88328bb72c8fd306a8cbe