### PR TITLE
Include sales total in guillotine calculations

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -213,10 +213,60 @@ if (
                 'exchange_rates'=> $exchangeRates,
                 'provider'      => $productProvider,
             ]);
+
+            // Demonte kalemlerinin de dahil olduğu satış (Satış) tutarını hesapla
+            $profitRate       = (float) ($row['profit_margin'] ?? 0);
+            $currentCurrency  = $totals['currency'] ?? 'TRY';
+            $demonteCosts     = [];
+
+            $systemQty  = (int) ($row['quantity'] ?? 0);
+            $motorName  = (string) ($row['motor_system'] ?? '');
+            if ($motorName !== '') {
+                $motorProduct = $productProvider->getProduct($motorName);
+                if ($motorProduct) {
+                    $motorCurrency = strtoupper((string) ($motorProduct['price_unit'] ?? 'TRY'));
+                    $motorPrice    = (float) ($motorProduct['unit_price'] ?? 0);
+                    if ($motorCurrency !== $currentCurrency) {
+                        $rate = $exchangeRates[$motorCurrency] ?? null;
+                        if ($rate !== null) {
+                            $motorPrice *= $rate;
+                        }
+                    }
+                    $demonteCosts[] = $motorPrice * $systemQty;
+                }
+            }
+
+            $remoteQty = (int) ($row['remote_quantity'] ?? 0);
+            if ($remoteQty > 0) {
+                $remoteProduct = $productProvider->getProduct('Kumanda');
+                if ($remoteProduct) {
+                    $remoteCurrency = strtoupper((string) ($remoteProduct['price_unit'] ?? 'TRY'));
+                    $remotePrice    = (float) ($remoteProduct['unit_price'] ?? 0);
+                    if ($remoteCurrency !== $currentCurrency) {
+                        $rate = $exchangeRates[$remoteCurrency] ?? null;
+                        if ($rate !== null) {
+                            $remotePrice *= $rate;
+                        }
+                    }
+                    $demonteCosts[] = $remotePrice * $remoteQty;
+                }
+            }
+
+            $demonteProfit = 0.0;
+            $demonteTotal  = 0.0;
+            foreach ($demonteCosts as $cost) {
+                $itemProfit    = $cost * $profitRate / 100;
+                $demonteProfit += $itemProfit;
+                $demonteTotal  += $cost + $itemProfit;
+            }
+
+            $salesTotal    = $totals['totals']['grand_total'] + $demonteTotal;
+            $updatedProfit = $totals['totals']['profit'] + $demonteProfit;
+
             $gUpd = $pdo->prepare('UPDATE guillotinesystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
             $gUpd->execute([
-                ':pamount' => $totals['totals']['profit'],
-                ':tamount' => $totals['totals']['grand_total'],
+                ':pamount' => $updatedProfit,
+                ':tamount' => $salesTotal,
                 ':id'      => $gId,
             ]);
 
@@ -396,10 +446,60 @@ if ($gPost) {
                             'exchange_rates'=> $exchangeRates,
                             'provider'      => $productProvider,
                         ]);
+
+                        // Demonte kalemleri üzerinden Satış tutarını belirle
+                        $profitRate       = (float) ($row['profit_margin'] ?? 0);
+                        $currentCurrency  = $totals['currency'] ?? 'TRY';
+                        $demonteCosts     = [];
+
+                        $systemQty = (int) ($row['quantity'] ?? 0);
+                        $motorName = (string) ($row['motor_system'] ?? '');
+                        if ($motorName !== '') {
+                            $motorProduct = $productProvider->getProduct($motorName);
+                            if ($motorProduct) {
+                                $motorCurrency = strtoupper((string) ($motorProduct['price_unit'] ?? 'TRY'));
+                                $motorPrice    = (float) ($motorProduct['unit_price'] ?? 0);
+                                if ($motorCurrency !== $currentCurrency) {
+                                    $rate = $exchangeRates[$motorCurrency] ?? null;
+                                    if ($rate !== null) {
+                                        $motorPrice *= $rate;
+                                    }
+                                }
+                                $demonteCosts[] = $motorPrice * $systemQty;
+                            }
+                        }
+
+                        $remoteQty = (int) ($row['remote_quantity'] ?? 0);
+                        if ($remoteQty > 0) {
+                            $remoteProduct = $productProvider->getProduct('Kumanda');
+                            if ($remoteProduct) {
+                                $remoteCurrency = strtoupper((string) ($remoteProduct['price_unit'] ?? 'TRY'));
+                                $remotePrice    = (float) ($remoteProduct['unit_price'] ?? 0);
+                                if ($remoteCurrency !== $currentCurrency) {
+                                    $rate = $exchangeRates[$remoteCurrency] ?? null;
+                                    if ($rate !== null) {
+                                        $remotePrice *= $rate;
+                                    }
+                                }
+                                $demonteCosts[] = $remotePrice * $remoteQty;
+                            }
+                        }
+
+                        $demonteProfit = 0.0;
+                        $demonteTotal  = 0.0;
+                        foreach ($demonteCosts as $cost) {
+                            $itemProfit    = $cost * $profitRate / 100;
+                            $demonteProfit += $itemProfit;
+                            $demonteTotal  += $cost + $itemProfit;
+                        }
+
+                        $salesTotal    = $totals['totals']['grand_total'] + $demonteTotal;
+                        $updatedProfit = $totals['totals']['profit'] + $demonteProfit;
+
                         $gUpd = $pdo->prepare('UPDATE guillotinesystems SET profit_amount=:pamount, total_amount=:tamount WHERE id=:id');
                         $gUpd->execute([
-                            ':pamount' => $totals['totals']['profit'],
-                            ':tamount' => $totals['totals']['grand_total'],
+                            ':pamount' => $updatedProfit,
+                            ':tamount' => $salesTotal,
                             ':id' => $gId,
                         ]);
                     }


### PR DESCRIPTION
## Summary
- compute sales total with motor and remote costs when recalculating guillotine rows
- update guillotine inserts/updates to store sales total and profit including demonte items

## Testing
- `php -l quotation_view.php`
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7db7e52748328b39a6e46f1479f9e