### PR TITLE
Add print function and improve table styling

### DIFF
--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -566,7 +566,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $tot       = $result['totals'];
     // Yeni kart ızgarası çıktısı
     echo '<style>
-@page { size: A4; margin: 10mm; }
+@page { size: A4; margin: 1.8mm; }
 .product-grid { display: grid; gap: 0.5rem; grid-template-columns: repeat(auto-fill,minmax(200px,1fr)); }
 @media (min-width:768px){ .product-grid { grid-template-columns: repeat(2,1fr); } }
 @media (min-width:992px){ .product-grid { grid-template-columns: repeat(3,1fr); } }
@@ -575,11 +575,14 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
 .product-card table { width:100%; font-size:0.8rem; text-align:center; }
 .product-card th { font-weight:600; }
 .product-img { width:100%; height:130px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
+.print-table th { background-color:#f8f9fa; }
+.print-table td, .print-table th { padding:4px; }
 </style>';
 
     echo '<div class="container mt-4 d-print-none">';
-    echo '    <button type="button" onclick="window.print()" class="btn btn-secondary">🖨️ Yazdır</button>';
+    echo '    <button type="button" onclick="yazdir()" class="btn btn-secondary">🖨️ Yazdır</button>';
     echo '</div>';
+    echo '<script>function yazdir(){ window.print(); }</script>';
 
     echo '<div class="text-center mb-4">';
     if (!empty($company['logo']) && file_exists(__DIR__ . '/assets/' . $company['logo'])) {
@@ -598,7 +601,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $ralCode   = trim((string) ($row['ral_code'] ?? ''));
 
     echo '<div class="col mb-3">';
-    echo '<table class="table table-bordered table-sm w-auto mb-0" style="background-color:#fff;"><tbody>';
+    echo '<table class="table table-bordered table-striped table-sm w-auto mb-0 print-table" style="background-color:#fff;"><tbody>';
     echo '<tr><th>Sistem Genişliği</th><td>' . e($sysWidth) . '</td></tr>';
     echo '<tr><th>Sistem Yüksekliği</th><td>' . e($sysHeight) . '</td></tr>';
     echo '<tr><th>Sistem Adedi</th><td>' . e($sysQtyVal) . '</td></tr>';
@@ -622,7 +625,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $glassColor  = trim((string) ($row['glass_color'] ?? ''));
 
     echo '<div class="col mb-3">';
-    echo '<table class="table table-bordered table-sm w-auto mb-0" style="background-color:#fff;">';
+    echo '<table class="table table-bordered table-striped table-sm w-auto mb-0 print-table" style="background-color:#fff;">';
     echo '<thead><tr>';
     echo '<th>Cam Genişliği</th>';
     echo '<th>Cam Yüksekliği</th>';
@@ -652,7 +655,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     echo '<div class="col mb-3">';
     echo '<div class="d-flex gap-3 align-items-start">';
 
-    echo '<table class="table table-bordered table-sm w-auto mb-0" style="background-color:#fff;">';
+    echo '<table class="table table-bordered table-striped table-sm w-auto mb-0 print-table" style="background-color:#fff;">';
     echo '<thead><tr>';
     echo '<th>Müşteri Bilgileri</th>';
     echo '<th></th>';


### PR DESCRIPTION
## Summary
- add dedicated `yazdir()` print function and configure A4 page with 1.8mm margins
- enhance system, glass, and customer tables with striped `print-table` styling for cleaner output

## Testing
- `phpunit --testdox tests/ReactivateOfferTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b828dc8b88832889ae75bf45bbb66f