### PR TITLE
Refine print layout for A4 output

### DIFF
--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -567,19 +567,19 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     // Yeni kart ızgarası çıktısı
     echo '<style>
 @page { size: A4; }
-.product-grid { display: grid; gap: 0.25rem; grid-template-columns: repeat(auto-fill,minmax(160px,1fr)); }
+.product-grid { display: grid; gap: 0.125rem; grid-template-columns: repeat(auto-fill,minmax(140px,1fr)); }
 @media (min-width:768px){ .product-grid { grid-template-columns: repeat(2,1fr); } }
 @media (min-width:992px){ .product-grid { grid-template-columns: repeat(3,1fr); } }
 @media print {
   .product-grid { grid-template-columns: repeat(3,1fr); }
 }
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }
-.product-card table { width:100%; font-size:0.7rem; text-align:center; border-collapse:collapse; }
-.product-card th, .product-card td { padding:0.25rem; }
+.product-card table { width:100%; font-size:0.6rem; text-align:center; border-collapse:collapse; }
+.product-card th, .product-card td { padding:0.15rem; }
   .product-card th { font-weight:600; }
-  .product-img { width:100%; height:100px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
-  .info-table { font-size:0.75rem; }
-.info-table th, .info-table td { padding:0.25rem; }
+  .product-img { width:100%; height:80px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
+  .info-table { font-size:0.7rem; }
+.info-table th, .info-table td { padding:0.15rem; }
 </style>';
 
     echo '<div class="container d-print-none text-end">';

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -507,7 +507,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     //
     $id = filter_input(INPUT_GET, 'quote_id', FILTER_VALIDATE_INT);
     if (!$id) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Geçersiz giyotin.</div></div>';
+        echo '<div class="container"><div class="alert alert-danger">Geçersiz giyotin.</div></div>';
         require __DIR__ . '/footer.php';
         exit;
     }
@@ -520,7 +520,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $stmt->execute([':id' => $id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$row) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Giyotin satırı bulunamadı.</div></div>';
+        echo '<div class="container"><div class="alert alert-danger">Giyotin satırı bulunamadı.</div></div>';
         require __DIR__ . '/footer.php';
         exit;
     }
@@ -548,7 +548,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
             'provider'      => $provider,
         ]);
     } catch (Throwable $e) {
-        echo '<div class="container mt-4"><div class="alert alert-danger">Hesaplama hatası: ' . e($e->getMessage()) . '</div></div>';
+        echo '<div class="container"><div class="alert alert-danger">Hesaplama hatası: ' . e($e->getMessage()) . '</div></div>';
         require __DIR__ . '/footer.php';
         exit;
     }
@@ -566,33 +566,31 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $tot       = $result['totals'];
     // Yeni kart ızgarası çıktısı
     echo '<style>
-@page { size: A4; margin: 0; }
-body { margin:0; }
+@page { size: A4; }
 .product-grid { display: grid; gap: 0.25rem; grid-template-columns: repeat(auto-fill,minmax(160px,1fr)); }
 @media (min-width:768px){ .product-grid { grid-template-columns: repeat(2,1fr); } }
 @media (min-width:992px){ .product-grid { grid-template-columns: repeat(3,1fr); } }
 @media print {
-  body { margin:0; }
   .product-grid { grid-template-columns: repeat(3,1fr); }
 }
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }
 .product-card table { width:100%; font-size:0.7rem; text-align:center; border-collapse:collapse; }
-.product-card th, .product-card td { padding:0; }
+.product-card th, .product-card td { padding:0.25rem; }
   .product-card th { font-weight:600; }
   .product-img { width:100%; height:100px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
   .info-table { font-size:0.75rem; }
-.info-table th, .info-table td { padding:0; }
+.info-table th, .info-table td { padding:0.25rem; }
 </style>';
 
-    echo '<div class="container mt-4 d-print-none text-end">';
+    echo '<div class="container d-print-none text-end">';
     echo '    <button type="button" onclick="window.print()" class="btn btn-secondary btn-sm">🖨️ Yazdır</button>';
     echo '</div>';
 
-    echo '<div class="text-center mb-4">';
+    echo '<div class="text-center">';
     if (!empty($company['logo']) && file_exists(__DIR__ . '/assets/' . $company['logo'])) {
-        echo '<img src="assets/' . e($company['logo']) . '" alt="' . e($company['name']) . ' Logo" class="mb-2" style="max-height:60px;">';
+        echo '<img src="assets/' . e($company['logo']) . '" alt="' . e($company['name']) . ' Logo" style="max-height:60px;">';
     }
-    echo '<h2 class="h5 fw-bold mb-0">GİYOTİN SİSTEMİ</h2>';
+    echo '<h2 class="h5 fw-bold">GİYOTİN SİSTEMİ</h2>';
     echo '</div>';
     echo '<div class="row">';
 
@@ -604,8 +602,8 @@ body { margin:0; }
     $motorName = trim((string) ($row['motor_system'] ?? ''));
     $ralCode   = trim((string) ($row['ral_code'] ?? ''));
 
-    echo '<div class="col mb-3">';
-    echo '<table class="table table-bordered table-sm w-auto mb-0 info-table" style="background-color:#fff;"><tbody>';
+    echo '<div class="col">';
+    echo '<table class="table table-bordered table-sm w-auto info-table" style="background-color:#fff;"><tbody>';
     echo '<tr><th>Sistem Genişliği</th><td>' . e($sysWidth) . '</td></tr>';
     echo '<tr><th>Sistem Yüksekliği</th><td>' . e($sysHeight) . '</td></tr>';
     echo '<tr><th>Sistem Adedi</th><td>' . e($sysQtyVal) . '</td></tr>';
@@ -628,8 +626,8 @@ body { margin:0; }
     $glassType   = trim((string) ($row['glass_type'] ?? ''));
     $glassColor  = trim((string) ($row['glass_color'] ?? ''));
 
-    echo '<div class="col mb-3">';
-    echo '<table class="table table-bordered table-sm w-auto mb-0 info-table" style="background-color:#fff;">';
+    echo '<div class="col">';
+    echo '<table class="table table-bordered table-sm w-auto info-table" style="background-color:#fff;">';
     echo '<thead><tr>';
     echo '<th>Cam Genişliği</th>';
     echo '<th>Cam Yüksekliği</th>';
@@ -656,10 +654,10 @@ body { margin:0; }
     }
     $glassArea = ($result['glass']['width'] * $result['glass']['height'] * $result['glass']['quantity']) / 1000000;
 
-    echo '<div class="col mb-3">';
+    echo '<div class="col">';
     echo '<div class="d-flex gap-3 align-items-start">';
 
-    echo '<table class="table table-bordered table-sm w-auto mb-0 info-table" style="background-color:#fff;">';
+    echo '<table class="table table-bordered table-sm w-auto info-table" style="background-color:#fff;">';
     echo '<thead><tr>';
     echo '<th>Müşteri Bilgileri</th>';
     echo '<th></th>';
@@ -689,17 +687,17 @@ body { margin:0; }
     echo '</td><td valign="top">';
 
     // --- Sağ Sütun: Sistem / Alüminyum / Cam ---
-    echo '<div class="mb-2">';
+    echo '<div>';
     echo '  <div><strong>Sistem</strong></div>';
     echo '  <div>' . e(number_format($systemArea, 2, ',', '.')) . '</div>';
     echo '</div>';
 
-    echo '<div class="mb-2">';
+    echo '<div>';
     echo '  <div><strong>Alüminyum</strong></div>';
     echo '  <div>' . e(number_format($aluminumTotal, 2, ',', '.')) . '</div>';
     echo '</div>';
 
-    echo '<div class="mb-2">';
+    echo '<div>';
     echo '  <div><strong>Cam</strong></div>';
     echo '  <div>' . e(number_format($glassArea, 2, ',', '.')) . '</div>';
     echo '</div>';
@@ -726,7 +724,7 @@ body { margin:0; }
         echo '<div class="product-card">';
         $qtyVal = number_format((int) ($line['pieces'] ?? 0), 0, ',', '.');
         $measureVal = number_format($line['measure'], 0, ',', '.');
-        echo '<table class="table table-bordered table-sm mb-0">';
+        echo '<table class="table table-bordered table-sm">';
         echo '<thead><tr><th>İsim</th><th>Kod</th><th>Ölçü</th><th>Adet</th></tr></thead>';
         echo '<tbody><tr><td>' . e($line['name']) . '</td><td>' . e($line['product_code'] ?? '') . '</td><td>' . e($measureVal) . '</td><td>' . e($qtyVal) . '</td></tr></tbody>';
         echo '</table>';

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -574,12 +574,12 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
   .product-grid { grid-template-columns: repeat(3,1fr); }
 }
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }
-.product-card table { width:100%; font-size:0.6rem; text-align:center; border-collapse:collapse; }
-.product-card th, .product-card td { padding:0.15rem; }
+.product-card table { width:100%; font-size:0.5rem; text-align:center; border-collapse:collapse; }
+.product-card th, .product-card td { padding:0.1rem; }
   .product-card th { font-weight:600; }
-  .product-img { width:100%; height:80px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
-  .info-table { font-size:0.7rem; }
-.info-table th, .info-table td { padding:0.15rem; }
+  .product-img { width:100%; height:60px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
+  .info-table { font-size:0.6rem; }
+.info-table th, .info-table td { padding:0.1rem; }
 </style>';
 
     echo '<div class="container d-print-none text-end">';

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -577,11 +577,11 @@ body { margin:0; }
 }
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }
 .product-card table { width:100%; font-size:0.7rem; text-align:center; border-collapse:collapse; }
-.product-card th, .product-card td { padding:2px; }
+.product-card th, .product-card td { padding:0; }
   .product-card th { font-weight:600; }
   .product-img { width:100%; height:100px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
   .info-table { font-size:0.75rem; }
-  .info-table th, .info-table td { padding:2px; }
+.info-table th, .info-table td { padding:0; }
 </style>';
 
     echo '<div class="container mt-4 d-print-none text-end">';

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -578,8 +578,10 @@ body { margin:0; }
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }
 .product-card table { width:100%; font-size:0.7rem; text-align:center; border-collapse:collapse; }
 .product-card th, .product-card td { padding:2px; }
-.product-card th { font-weight:600; }
-.product-img { width:100%; height:100px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
+  .product-card th { font-weight:600; }
+  .product-img { width:100%; height:100px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
+  .info-table { font-size:0.75rem; }
+  .info-table th, .info-table td { padding:2px; }
 </style>';
 
     echo '<div class="container mt-4 d-print-none text-end">';
@@ -603,7 +605,7 @@ body { margin:0; }
     $ralCode   = trim((string) ($row['ral_code'] ?? ''));
 
     echo '<div class="col mb-3">';
-    echo '<table class="table table-bordered table-sm w-auto mb-0" style="background-color:#fff;"><tbody>';
+    echo '<table class="table table-bordered table-sm w-auto mb-0 info-table" style="background-color:#fff;"><tbody>';
     echo '<tr><th>Sistem Genişliği</th><td>' . e($sysWidth) . '</td></tr>';
     echo '<tr><th>Sistem Yüksekliği</th><td>' . e($sysHeight) . '</td></tr>';
     echo '<tr><th>Sistem Adedi</th><td>' . e($sysQtyVal) . '</td></tr>';
@@ -627,7 +629,7 @@ body { margin:0; }
     $glassColor  = trim((string) ($row['glass_color'] ?? ''));
 
     echo '<div class="col mb-3">';
-    echo '<table class="table table-bordered table-sm w-auto mb-0" style="background-color:#fff;">';
+    echo '<table class="table table-bordered table-sm w-auto mb-0 info-table" style="background-color:#fff;">';
     echo '<thead><tr>';
     echo '<th>Cam Genişliği</th>';
     echo '<th>Cam Yüksekliği</th>';
@@ -657,7 +659,7 @@ body { margin:0; }
     echo '<div class="col mb-3">';
     echo '<div class="d-flex gap-3 align-items-start">';
 
-    echo '<table class="table table-bordered table-sm w-auto mb-0" style="background-color:#fff;">';
+    echo '<table class="table table-bordered table-sm w-auto mb-0 info-table" style="background-color:#fff;">';
     echo '<thead><tr>';
     echo '<th>Müşteri Bilgileri</th>';
     echo '<th></th>';

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -566,13 +566,13 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $tot       = $result['totals'];
     // Yeni kart ızgarası çıktısı
     echo '<style>
-@page { size: A4; margin: 10mm; }
+@page { size: A4; margin: 0; }
 body { margin:0; }
 .product-grid { display: grid; gap: 0.25rem; grid-template-columns: repeat(auto-fill,minmax(160px,1fr)); }
 @media (min-width:768px){ .product-grid { grid-template-columns: repeat(2,1fr); } }
 @media (min-width:992px){ .product-grid { grid-template-columns: repeat(3,1fr); } }
 @media print {
-  body { margin:10mm; }
+  body { margin:0; }
   .product-grid { grid-template-columns: repeat(3,1fr); }
 }
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }

--- a/optimizasyon.php
+++ b/optimizasyon.php
@@ -567,18 +567,23 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     // Yeni kart ızgarası çıktısı
     echo '<style>
 @page { size: A4; margin: 10mm; }
-.product-grid { display: grid; gap: 0.5rem; grid-template-columns: repeat(auto-fill,minmax(200px,1fr)); }
+body { margin:0; }
+.product-grid { display: grid; gap: 0.25rem; grid-template-columns: repeat(auto-fill,minmax(160px,1fr)); }
 @media (min-width:768px){ .product-grid { grid-template-columns: repeat(2,1fr); } }
 @media (min-width:992px){ .product-grid { grid-template-columns: repeat(3,1fr); } }
-@media print { .product-grid { grid-template-columns: repeat(3,1fr); } }
+@media print {
+  body { margin:10mm; }
+  .product-grid { grid-template-columns: repeat(3,1fr); }
+}
 .product-card { border:1px solid #000; page-break-inside: avoid; break-inside: avoid; }
-.product-card table { width:100%; font-size:0.8rem; text-align:center; }
+.product-card table { width:100%; font-size:0.7rem; text-align:center; border-collapse:collapse; }
+.product-card th, .product-card td { padding:2px; }
 .product-card th { font-weight:600; }
-.product-img { width:100%; height:130px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
+.product-img { width:100%; height:100px; object-fit:contain; border:1px solid #000; display:block; background-color:#fff; }
 </style>';
 
     echo '<div class="container mt-4 d-print-none text-end">';
-    echo '    <button type="button" onclick="window.print()" class="btn btn-secondary">🖨️ Yazdır</button>';
+    echo '    <button type="button" onclick="window.print()" class="btn btn-secondary btn-sm">🖨️ Yazdır</button>';
     echo '</div>';
 
     echo '<div class="text-center mb-4">';


### PR DESCRIPTION
## Summary
- Tighter card grid and reduced image/table sizes to better fit A4 pages with margins
- Added print-specific CSS and body margins for cleaner output
- Made print button compact using `btn-sm`

## Testing
- `php -l optimizasyon.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8388d99bc8328bd99c606626dc3ea